### PR TITLE
Remove assert_matches feature which requires nightly

### DIFF
--- a/rhio/src/lib.rs
+++ b/rhio/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(assert_matches)]
-
 pub mod actor;
 pub mod aggregate;
 pub mod config;

--- a/rhio/src/main.rs
+++ b/rhio/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(assert_matches)]
-
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/rhio/src/node.rs
+++ b/rhio/src/node.rs
@@ -167,7 +167,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
     use std::time::Duration;
 
     use p2panda_net::{network::OutEvent, Config};
@@ -221,8 +220,8 @@ mod tests {
         let rx_1_msg = rx_1.recv().await.unwrap();
 
         // Ensure the gossip-overlay has been joined for the given topic
-        assert_matches!(rx_1_msg, OutEvent::Ready);
-        assert_matches!(rx_2_msg, OutEvent::Ready);
+        assert!(matches!(rx_1_msg, OutEvent::Ready));
+        assert!(matches!(rx_2_msg, OutEvent::Ready));
 
         // Return a list of peers known to the first node
         let known_peers_1 = node_1.network.known_peers().await.unwrap();


### PR DESCRIPTION
This PR removes the [assert_matches](https://doc.rust-lang.org/std/assert_matches/macro.assert_matches.html) feature which requires nightly, since the feature is so small and opting into nightly a much larger requirement, I've decided to remove it for now, hope that is okay? If we want developers to use nightly we should mention this in a `rust-toolchain.toml` file. 