### PR TITLE
Integrate S3 blobs store with rhio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,11 +260,11 @@ dependencies = [
 
 [[package]]
 name = "attohttpc"
-version = "0.26.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f77d243921b0979fbbd728dd2d5162e68ac8252976797c24eb5b3a6af9090dc"
+checksum = "9a13149d0cf3f7f9b9261fad4ec63b2efbf9a80665f52def86282d26255e6331"
 dependencies = [
- "http 0.2.12",
+ "http 1.1.0",
  "log",
  "native-tls",
  "serde",
@@ -280,11 +280,11 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-creds"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390ad3b77f3e21e01a4a0355865853b681daf1988510b0b15e31c0c4ae7eb0f6"
+checksum = "7f84143206b9c72b3c5cb65415de60c7539c79cd1559290fddec657939131be0"
 dependencies = [
- "attohttpc 0.26.1",
+ "attohttpc 0.28.0",
  "home",
  "log",
  "quick-xml",
@@ -791,7 +791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.5",
+ "hashbrown",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1536,12 +1536,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1555,7 +1549,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2078,7 +2072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3002,12 +2996,12 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-multimap"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
- "hashbrown 0.13.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3055,7 +3049,7 @@ dependencies = [
  "iroh-io",
  "iroh-net",
  "num_cpus",
- "p2panda-core 0.1.0 (git+https://github.com/p2panda/p2panda.git?rev=14e45f807d800c79a3caa5d918b99d83f6e0cce9)",
+ "p2panda-core",
  "p2panda-net",
  "p2panda-sync",
  "serde",
@@ -3064,21 +3058,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "p2panda-core"
-version = "0.1.0"
-source = "git+https://github.com/p2panda/p2panda.git?branch=v2#6b573408e8d977701fdb627023b818b7d33bc9bd"
-dependencies = [
- "blake3",
- "ciborium",
- "ed25519-dalek",
- "hex",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -3122,7 +3101,7 @@ dependencies = [
  "ciborium",
  "futures-channel",
  "futures-util",
- "p2panda-core 0.1.0 (git+https://github.com/p2panda/p2panda.git?rev=14e45f807d800c79a3caa5d918b99d83f6e0cce9)",
+ "p2panda-core",
  "p2panda-store",
  "pin-project",
  "pin-utils",
@@ -3144,7 +3123,7 @@ dependencies = [
  "iroh-gossip",
  "iroh-net",
  "iroh-quinn",
- "p2panda-core 0.1.0 (git+https://github.com/p2panda/p2panda.git?rev=14e45f807d800c79a3caa5d918b99d83f6e0cce9)",
+ "p2panda-core",
  "p2panda-discovery",
  "p2panda-sync",
  "rand 0.8.5",
@@ -3161,7 +3140,7 @@ name = "p2panda-store"
 version = "0.1.0"
 source = "git+https://github.com/p2panda/p2panda.git?rev=14e45f807d800c79a3caa5d918b99d83f6e0cce9#14e45f807d800c79a3caa5d918b99d83f6e0cce9"
 dependencies = [
- "p2panda-core 0.1.0 (git+https://github.com/p2panda/p2panda.git?rev=14e45f807d800c79a3caa5d918b99d83f6e0cce9)",
+ "p2panda-core",
  "trait-variant",
 ]
 
@@ -3172,7 +3151,7 @@ source = "git+https://github.com/p2panda/p2panda.git?rev=14e45f807d800c79a3caa5d
 dependencies = [
  "async-trait",
  "futures",
- "p2panda-core 0.1.0 (git+https://github.com/p2panda/p2panda.git?rev=14e45f807d800c79a3caa5d918b99d83f6e0cce9)",
+ "p2panda-core",
  "p2panda-store",
  "serde",
  "thiserror 1.0.63",
@@ -3681,9 +3660,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
  "serde",
@@ -4105,7 +4084,7 @@ dependencies = [
  "hex",
  "iroh-blobs",
  "p2panda-blobs",
- "p2panda-core 0.1.0 (git+https://github.com/p2panda/p2panda.git?rev=14e45f807d800c79a3caa5d918b99d83f6e0cce9)",
+ "p2panda-core",
  "p2panda-engine",
  "p2panda-net",
  "p2panda-store",
@@ -4131,7 +4110,7 @@ dependencies = [
  "futures-lite 2.5.0",
  "iroh-blobs",
  "iroh-io",
- "p2panda-core 0.1.0 (git+https://github.com/p2panda/p2panda.git?branch=v2)",
+ "p2panda-core",
  "rust-s3",
  "thiserror 2.0.3",
  "tokio",
@@ -4148,7 +4127,7 @@ dependencies = [
  "ciborium",
  "constcat",
  "hex",
- "p2panda-core 0.1.0 (git+https://github.com/p2panda/p2panda.git?rev=14e45f807d800c79a3caa5d918b99d83f6e0cce9)",
+ "p2panda-core",
  "p2panda-engine",
  "p2panda-store",
  "p2panda-sync",
@@ -4213,24 +4192,25 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+ "trim-in-place",
 ]
 
 [[package]]
 name = "rust-s3"
-version = "0.34.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6679da8efaf4c6f0c161de0961dfe95fb6e9049c398d6fbdada2639f053aedb"
+checksum = "c3df3f353b1f4209dcf437d777cda90279c397ab15a0cd6fd06bd32c88591533"
 dependencies = [
  "async-trait",
  "aws-creds",
  "aws-region",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "futures",
@@ -5284,7 +5264,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -5433,6 +5413,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4112,6 +4112,8 @@ dependencies = [
  "iroh-io",
  "p2panda-core",
  "rust-s3",
+ "serde",
+ "serde_json",
  "thiserror 2.0.3",
  "tokio",
  "tracing",
@@ -4525,9 +4527,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4497,9 +4497,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -4534,9 +4534,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4133,6 +4133,7 @@ dependencies = [
  "p2panda-engine",
  "p2panda-store",
  "p2panda-sync",
+ "rhio-blobs",
  "serde",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,28 +228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4118,7 +4096,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-nats",
- "async-stream",
  "async-trait",
  "ciborium",
  "clap",
@@ -4134,6 +4111,7 @@ dependencies = [
  "p2panda-store",
  "p2panda-sync",
  "rand 0.8.5",
+ "rhio-blobs",
  "rhio-core",
  "rust-s3",
  "serde",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -87,8 +87,8 @@
 
 # publish:
 #   s3_buckets:
-#     - "local_bucket_1"
-#     - "local_bucket_2"
+#     - "local-bucket-1"
+#     - "local-bucket-2"
 #   nats_subjects:
 #     - subject: "<public_key>.workload.berlin.energy"
 #       stream: "workload"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -76,7 +76,7 @@
 # (they need to be hosted with a static IP address).
 #
 # nodes:
-#   - public_key: "6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a"
+#   - public_key: "<public-key>"
 #     endpoints:
 #       - "192.168.178.100:9102"
 #       - "[2a02:8109:9c9a:4200:eb13:7c0a:4201:8128]:9103"
@@ -87,20 +87,20 @@
 
 # publish:
 #   s3_buckets:
-#     - "local-bucket-1"
-#     - "local-bucket-2"
+#     - "bucket-1"
+#     - "bucket-2"
 #   nats_subjects:
-#     - subject: "<public_key>.workload.berlin.energy"
+#     - subject: "<public-key>.workload.berlin.energy"
 #       stream: "workload"
-#     - subject: "<public_key>.workload.rotterdam.energy"
+#     - subject: "<public-key>.workload.rotterdam.energy"
 #       stream: "workload"
 #
 # subscribe:
 #   s3_buckets:
-#     - "<public_key>/remote_bucket_1"
-#     - "<public_key>/remote_bucket_2"
+#     - "bucket-1/<public-key>"
+#     - "bucket-2/<public-key>"
 #   nats_subjects:
-#     - subject: "<public_key>.workload.*.energy"
+#     - subject: "<public-key>.workload.*.energy"
 #       stream: "workload"
-#     - subject: "<public_key>.data.thehague.meta"
+#     - subject: "<public-key>.data.thehague.meta"
 #       stream: "data"

--- a/rhio-blobs/Cargo.toml
+++ b/rhio-blobs/Cargo.toml
@@ -14,6 +14,8 @@ iroh-blobs = "0.25.0"
 iroh-io = { version = "0.6.1", features = ["x-http"] }
 p2panda-core = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f807d800c79a3caa5d918b99d83f6e0cce9" }
 rust-s3 = { version = "0.35.1", features = ["tokio"] }
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.132"
 thiserror = "2.0.3"
 tokio = "1.41.1"
 tracing = "0.1.40"

--- a/rhio-blobs/Cargo.toml
+++ b/rhio-blobs/Cargo.toml
@@ -3,18 +3,18 @@ name = "rhio-blobs"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.93"
 bytes = "1.8.0"
 futures-lite = "2.5.0"
 iroh-blobs = "0.25.0"
 iroh-io = { version = "0.6.1", features = ["x-http"] }
-p2panda-core = { git = "https://github.com/p2panda/p2panda.git", branch = "v2" }
-rust-s3 = { version = "0.34.0", features = ["tokio"] }
+p2panda-core = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f807d800c79a3caa5d918b99d83f6e0cce9" }
+rust-s3 = { version = "0.35.1", features = ["tokio"] }
 thiserror = "2.0.3"
 tokio = "1.41.1"
 tracing = "0.1.40"
 url = "2.5.3"
-
-[lints]
-workspace = true

--- a/rhio-blobs/src/bao_file.rs
+++ b/rhio-blobs/src/bao_file.rs
@@ -8,8 +8,8 @@ use iroh_io::AsyncSliceReader;
 use s3::Bucket;
 use serde::{Deserialize, Serialize};
 
-use crate::paths::Paths;
 use crate::s3_file::S3File;
+use crate::Paths;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BaoMeta {

--- a/rhio-blobs/src/bao_file.rs
+++ b/rhio-blobs/src/bao_file.rs
@@ -61,7 +61,7 @@ impl BaoFileHandle {
     ///
     /// This method returns a handle onto an incomplete BAO file using the expected paths. It
     /// doesn't create any files yet or transfer any data.
-    pub fn new(bucket: Box<Bucket>, paths: Paths, data_size: u64) -> Self {
+    pub fn new(bucket: Bucket, paths: Paths, data_size: u64) -> Self {
         Self {
             data: S3File::new(bucket.clone(), paths.data()),
             outboard: S3File::new(bucket.clone(), paths.outboard()),
@@ -77,7 +77,7 @@ impl BaoFileHandle {
     /// This method is for taking an existing blob and generating it's accompanying outboard file.
     /// It is useful when importing blobs from an s3 bucket directly into the store.
     pub async fn create_complete(
-        bucket: Box<Bucket>,
+        bucket: Bucket,
         path: String,
         size: u64,
     ) -> anyhow::Result<(Self, BaoMeta)> {

--- a/rhio-blobs/src/bao_file.rs
+++ b/rhio-blobs/src/bao_file.rs
@@ -3,16 +3,13 @@ use bytes::{Bytes, BytesMut};
 use iroh_blobs::store::bao_tree::io::fsm::{BaoContentItem, CreateOutboard};
 use iroh_blobs::store::bao_tree::io::outboard::PreOrderOutboard;
 use iroh_blobs::store::bao_tree::BaoTree;
-use iroh_blobs::Hash;
-
-use iroh_blobs::IROH_BLOCK_SIZE;
+use iroh_blobs::{Hash, IROH_BLOCK_SIZE};
 use iroh_io::AsyncSliceReader;
 use s3::Bucket;
 use serde::{Deserialize, Serialize};
 
 use crate::paths::Paths;
-
-use super::s3_file::S3File;
+use crate::s3_file::S3File;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BaoMeta {

--- a/rhio-blobs/src/bao_file.rs
+++ b/rhio-blobs/src/bao_file.rs
@@ -8,44 +8,28 @@ use iroh_blobs::Hash;
 use iroh_blobs::IROH_BLOCK_SIZE;
 use iroh_io::AsyncSliceReader;
 use s3::Bucket;
+use serde::{Deserialize, Serialize};
 
 use crate::paths::Paths;
 
 use super::s3_file::S3File;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BaoMeta {
     pub hash: Hash,
     pub size: u64,
     pub complete: bool,
+    #[serde(rename = "key")]
     pub path: String,
 }
 
 impl BaoMeta {
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(self.hash.as_bytes());
-        bytes.extend_from_slice(&self.size.to_le_bytes());
-        bytes.extend_from_slice(&(self.complete as i32).to_le_bytes());
-        bytes.extend_from_slice(self.path.as_bytes());
-        bytes
+        serde_json::to_vec(self).expect("json encoding of meta data")
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let hash_bytes: [u8; 32] = bytes[..32].try_into()?;
-        let hash = Hash::from_bytes(hash_bytes);
-        let size_bytes: [u8; 8] = bytes[32..40].try_into()?;
-        let size = u64::from_le_bytes(size_bytes);
-        let complete_bytes: [u8; 4] = bytes[40..44].try_into()?;
-        let complete = i32::from_le_bytes(complete_bytes) != 0;
-        let path = String::from_utf8(bytes[44..].to_vec())?;
-
-        Ok(Self {
-            size,
-            hash,
-            complete,
-            path,
-        })
+        Ok(serde_json::from_slice(bytes)?)
     }
 }
 

--- a/rhio-blobs/src/bao_file.rs
+++ b/rhio-blobs/src/bao_file.rs
@@ -61,7 +61,7 @@ impl BaoFileHandle {
     ///
     /// This method returns a handle onto an incomplete BAO file using the expected paths. It
     /// doesn't create any files yet or transfer any data.
-    pub fn new(bucket: Bucket, paths: Paths, data_size: u64) -> Self {
+    pub fn new(bucket: Box<Bucket>, paths: Paths, data_size: u64) -> Self {
         Self {
             data: S3File::new(bucket.clone(), paths.data()),
             outboard: S3File::new(bucket.clone(), paths.outboard()),
@@ -77,7 +77,7 @@ impl BaoFileHandle {
     /// This method is for taking an existing blob and generating it's accompanying outboard file.
     /// It is useful when importing blobs from an s3 bucket directly into the store.
     pub async fn create_complete(
-        bucket: Bucket,
+        bucket: Box<Bucket>,
         path: String,
         size: u64,
     ) -> anyhow::Result<(Self, BaoMeta)> {

--- a/rhio-blobs/src/lib.rs
+++ b/rhio-blobs/src/lib.rs
@@ -3,4 +3,12 @@ pub mod paths;
 pub mod s3_file;
 mod store;
 
+pub use iroh_blobs::Hash as BlobHash;
+
 pub use store::S3Store;
+
+pub type ObjectSize = u64;
+
+pub type ObjectKey = String;
+
+pub type BucketName = String;

--- a/rhio-blobs/src/lib.rs
+++ b/rhio-blobs/src/lib.rs
@@ -1,10 +1,11 @@
-pub mod bao_file;
-pub mod paths;
-pub mod s3_file;
+mod bao_file;
+mod paths;
+mod s3_file;
 mod store;
 
 pub use iroh_blobs::Hash as BlobHash;
 
+pub use paths::{Paths, META_SUFFIX, NO_PREFIX, OUTBOARD_SUFFIX};
 pub use store::S3Store;
 
 pub type ObjectSize = u64;

--- a/rhio-blobs/src/lib.rs
+++ b/rhio-blobs/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod bao_file;
 pub mod paths;
 pub mod s3_file;
-pub mod store;
+mod store;
 
 pub use s3;
+
+pub use store::S3Store;

--- a/rhio-blobs/src/lib.rs
+++ b/rhio-blobs/src/lib.rs
@@ -3,6 +3,4 @@ pub mod paths;
 pub mod s3_file;
 mod store;
 
-pub use s3;
-
 pub use store::S3Store;

--- a/rhio-blobs/src/paths.rs
+++ b/rhio-blobs/src/paths.rs
@@ -1,4 +1,5 @@
 pub const META_SUFFIX: &str = ".meta";
+pub const OUTBOARD_SUFFIX: &str = ".bao4";
 
 #[derive(Debug, Clone)]
 pub struct Paths {
@@ -19,6 +20,6 @@ impl Paths {
     }
 
     pub fn outboard(&self) -> String {
-        format!("{}.bao4", self.path)
+        format!("{}{OUTBOARD_SUFFIX}", self.path)
     }
 }

--- a/rhio-blobs/src/paths.rs
+++ b/rhio-blobs/src/paths.rs
@@ -1,5 +1,8 @@
 pub const META_SUFFIX: &str = ".meta";
+
 pub const OUTBOARD_SUFFIX: &str = ".bao4";
+
+pub const NO_PREFIX: String = String::new(); // Empty string.
 
 #[derive(Debug, Clone)]
 pub struct Paths {

--- a/rhio-blobs/src/paths.rs
+++ b/rhio-blobs/src/paths.rs
@@ -1,3 +1,5 @@
+pub const META_SUFFIX: &str = ".meta";
+
 #[derive(Debug, Clone)]
 pub struct Paths {
     path: String,
@@ -7,12 +9,15 @@ impl Paths {
     pub fn new(path: String) -> Self {
         Self { path }
     }
+
     pub fn data(&self) -> String {
-        self.path.to_string()
+        self.path.clone()
     }
+
     pub fn meta(&self) -> String {
-        format!("{}.meta", self.path)
+        format!("{}{META_SUFFIX}", self.path)
     }
+
     pub fn outboard(&self) -> String {
         format!("{}.bao4", self.path)
     }

--- a/rhio-blobs/src/s3_file.rs
+++ b/rhio-blobs/src/s3_file.rs
@@ -21,6 +21,7 @@ pub enum MultiPartBufferError {
     PartBufferDrained,
 }
 
+#[allow(dead_code)]
 pub enum MultiPartBufferResult {
     PartComplete(PartNumber, Offset, Vec<u8>),
     PartExtended(PartNumber, Offset),

--- a/rhio-blobs/src/s3_file.rs
+++ b/rhio-blobs/src/s3_file.rs
@@ -83,7 +83,7 @@ impl MultiPartBuffer {
 
 #[derive(Debug)]
 pub struct S3File {
-    bucket: Box<Bucket>,
+    bucket: Bucket,
     buffer: MultiPartBuffer,
     path: String,
     upload_id: Option<String>,
@@ -91,7 +91,7 @@ pub struct S3File {
 }
 
 impl S3File {
-    pub fn new(bucket: Box<Bucket>, path: String) -> Self {
+    pub fn new(bucket: Bucket, path: String) -> Self {
         Self {
             bucket,
             path,

--- a/rhio-blobs/src/s3_file.rs
+++ b/rhio-blobs/src/s3_file.rs
@@ -186,7 +186,9 @@ impl S3File {
     }
 
     pub fn reader(&self) -> HttpAdapter {
-        // @TODO: This currently requires the bucket to be _public_.
+        // @TODO(adz): This currently requires the bucket to be _public_. We can sign the HTTP
+        // request to fullfil the S3 authentication API or use the S3 API straight away.
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
         let url = self.bucket.url();
         HttpAdapter::new(url::Url::from_str(&format!("{url}/{}", &self.path)).unwrap())
     }

--- a/rhio-blobs/src/s3_file.rs
+++ b/rhio-blobs/src/s3_file.rs
@@ -176,7 +176,7 @@ impl S3File {
         };
 
         debug!(
-            path = %self.path,
+            key = %self.path,
             num_parts = %self.uploaded_parts.len(),
             bytes = %self.buffer.processed_bytes,
             "upload complete",

--- a/rhio-blobs/src/s3_file.rs
+++ b/rhio-blobs/src/s3_file.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use iroh_blobs::IROH_BLOCK_SIZE;
 use iroh_io::HttpAdapter;
 use s3::bucket::Bucket;
 use s3::serde_types::Part;
 use thiserror::Error;
-use tracing::{error, info};
+use tracing::{debug, error};
 
 /// The minimum size of a part in a multipart upload session.
 const MIN_PART_SIZE: usize = IROH_BLOCK_SIZE.bytes() * 1000;
@@ -112,10 +112,10 @@ impl S3File {
     /// restriction but it complicates the implementation and increases bug possibilities. This
     /// behavior would only occur when we download a blob from multiple peers in parallel, and as
     /// we can make sure this doesn't happen in the iroh blob download API I thought this was the
-    /// pragmatic approach for now.  
+    /// pragmatic approach for now.
     pub async fn write_all_at(&mut self, offset: usize, bytes: Vec<u8>) -> Result<()> {
         if self.buffer.processed_bytes != offset {
-            return Err(anyhow::anyhow!("bytes mut be written to the file in order"));
+            return Err(anyhow!("bytes mut be written to the file in order"));
         }
         let part_number = offset_to_part_number(MIN_PART_SIZE, offset);
         match self.buffer.extend(part_number, bytes) {
@@ -172,20 +172,21 @@ impl S3File {
 
         if response.status_code() != 200 {
             error!("uploading blob to minio bucket failed with: {response}");
-            return Err(anyhow::anyhow!(response));
+            return Err(anyhow!(response));
         };
 
-        info!(
-            "Upload complete: {:?} uploaded in {} parts ({} bytes)",
-            self.path,
-            self.uploaded_parts.len(),
-            self.buffer.processed_bytes,
+        debug!(
+            path = %self.path,
+            num_parts = %self.uploaded_parts.len(),
+            bytes = %self.buffer.processed_bytes,
+            "upload complete",
         );
 
         Ok(())
     }
 
     pub fn reader(&self) -> HttpAdapter {
+        // @TODO: This currently requires the bucket to be _public_.
         let url = self.bucket.url();
         HttpAdapter::new(url::Url::from_str(&format!("{url}/{}", &self.path)).unwrap())
     }

--- a/rhio-blobs/src/s3_file.rs
+++ b/rhio-blobs/src/s3_file.rs
@@ -100,6 +100,10 @@ impl S3File {
         }
     }
 
+    pub fn bucket_name(&self) -> String {
+        self.bucket.name()
+    }
+
     /// Write a byte buffer into the file at a particular offset.
     ///
     /// TODO: A current limitation of this implementation is that bytes are expected to be written

--- a/rhio-blobs/src/store.rs
+++ b/rhio-blobs/src/store.rs
@@ -29,13 +29,13 @@ use crate::paths::{Paths, META_SUFFIX, NO_PREFIX};
 /// Blob data and outboard files are stored in an s3 bucket.
 #[derive(Debug, Clone)]
 pub struct S3Store {
-    buckets: Vec<Box<Bucket>>,
+    buckets: Vec<Bucket>,
     inner: Arc<S3StoreInner>,
 }
 
 impl S3Store {
     /// Create a new S3 blob store interface for p2panda.
-    pub async fn new(buckets: Vec<Box<Bucket>>) -> Result<Self> {
+    pub async fn new(buckets: Vec<Bucket>) -> Result<Self> {
         let mut store = Self {
             buckets,
             inner: Default::default(),
@@ -44,7 +44,7 @@ impl S3Store {
         Ok(store)
     }
 
-    pub fn buckets(&self) -> &Vec<Box<Bucket>> {
+    pub fn buckets(&self) -> &Vec<Bucket> {
         self.buckets.as_ref()
     }
 
@@ -144,7 +144,7 @@ impl S3Store {
         self.inner.0.read().await
     }
 
-    fn bucket(&self, bucket_name: &str) -> Box<Bucket> {
+    fn bucket(&self, bucket_name: &str) -> Bucket {
         self.buckets
             .iter()
             .find(|bucket| bucket.name() == bucket_name)

--- a/rhio-blobs/src/store.rs
+++ b/rhio-blobs/src/store.rs
@@ -44,7 +44,7 @@ impl S3Store {
         Ok(store)
     }
 
-    /// Initiate the store from the content of an S3 bucket.
+    /// Initiate the store from the contents of given S3 buckets.
     ///
     /// This method looks at all `.meta` files present on the configured S3 buckets and establishes
     /// an index.
@@ -136,12 +136,10 @@ impl S3Store {
             .collect()
     }
 
-    /// Take a write lock on the store.
     async fn write_lock(&self) -> RwLockWriteGuard<'_, StateInner> {
         self.inner.0.write().await
     }
 
-    /// Take a read lock on the store.
     async fn read_lock(&self) -> RwLockReadGuard<'_, StateInner> {
         self.inner.0.read().await
     }

--- a/rhio-blobs/src/store.rs
+++ b/rhio-blobs/src/store.rs
@@ -22,7 +22,7 @@ use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::warn;
 
 use crate::bao_file::{get_meta, put_meta, BaoFileHandle, BaoMeta};
-use crate::paths::{Paths, META_SUFFIX};
+use crate::paths::{Paths, META_SUFFIX, NO_PREFIX};
 
 /// An s3 backed iroh blobs store.
 ///
@@ -54,8 +54,7 @@ impl S3Store {
     /// an index.
     async fn init(&mut self) -> Result<()> {
         for bucket in &self.buckets {
-            let results = bucket.list("/".to_string(), None).await?;
-
+            let results = bucket.list(NO_PREFIX, None).await?;
             for list in results {
                 for object in list.contents {
                     if object.key.ends_with(META_SUFFIX) {

--- a/rhio-blobs/src/store.rs
+++ b/rhio-blobs/src/store.rs
@@ -22,7 +22,7 @@ use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::warn;
 
 use crate::bao_file::{get_meta, put_meta, BaoFileHandle, BaoMeta};
-use crate::paths::Paths;
+use crate::paths::{Paths, META_SUFFIX};
 
 /// An s3 backed iroh blobs store.
 ///
@@ -54,12 +54,11 @@ impl S3Store {
     /// an index.
     async fn init(&mut self) -> Result<()> {
         for bucket in &self.buckets {
-            println!("{:?}", bucket);
             let results = bucket.list("/".to_string(), None).await?;
 
             for list in results {
                 for object in list.contents {
-                    if object.key.ends_with(".meta") {
+                    if object.key.ends_with(META_SUFFIX) {
                         let meta = get_meta(bucket, object.key).await?;
                         let paths = Paths::new(meta.path.clone());
                         let bao_file = BaoFileHandle::new(bucket.clone(), paths, meta.size);

--- a/rhio-core/Cargo.toml
+++ b/rhio-core/Cargo.toml
@@ -3,8 +3,11 @@ name = "rhio-core"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
-anyhow = "1.0.86"
+anyhow = "1.0.93"
 async-nats = "0.37.0"
 ciborium = "0.2.2"
 constcat = "0.5.1"
@@ -17,7 +20,4 @@ serde = { version = "1.0.209", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.10.1"
-tokio = { version = "1.40.0", features = ["rt", "macros"] }
-
-[lints]
-workspace = true
+tokio = { version = "1.41.1", features = ["rt", "macros"] }

--- a/rhio-core/Cargo.toml
+++ b/rhio-core/Cargo.toml
@@ -16,6 +16,7 @@ p2panda-core = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f80
 p2panda-engine = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f807d800c79a3caa5d918b99d83f6e0cce9" }
 p2panda-store = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f807d800c79a3caa5d918b99d83f6e0cce9" }
 p2panda-sync = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f807d800c79a3caa5d918b99d83f6e0cce9" }
+rhio-blobs = { path = "../rhio-blobs" }
 serde = { version = "1.0.209", features = ["derive"] }
 
 [dev-dependencies]

--- a/rhio-core/src/bucket.rs
+++ b/rhio-core/src/bucket.rs
@@ -3,18 +3,17 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, bail};
 use p2panda_core::PublicKey;
+use rhio_blobs::BucketName;
 use serde::{Deserialize, Serialize};
 
 const KEY_PREFIX_TOKEN: &str = "/";
-
-pub type Bucket = String;
 
 /// Special S3 bucket name for the "rhio" application which holds a regular S3 bucket name next to
 /// a peer's Ed25519 public key.
 ///
 /// This makes the S3 bucket name "scoped" to this particular identity.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ScopedBucket(Bucket, PublicKey);
+pub struct ScopedBucket(BucketName, PublicKey);
 
 impl ScopedBucket {
     pub fn new(bucket_name: &str, public_key: PublicKey) -> Self {
@@ -25,7 +24,7 @@ impl ScopedBucket {
         self.1
     }
 
-    pub fn bucket_name(&self) -> Bucket {
+    pub fn bucket_name(&self) -> BucketName {
         self.0.clone()
     }
 

--- a/rhio-core/src/bucket.rs
+++ b/rhio-core/src/bucket.rs
@@ -14,29 +14,35 @@ pub type Bucket = String;
 ///
 /// This makes the S3 bucket name "scoped" to this particular identity.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ScopedBucket(PublicKey, Bucket);
+pub struct ScopedBucket(Bucket, PublicKey);
 
 impl ScopedBucket {
-    pub fn new(public_key: PublicKey, bucket_name: &str) -> Self {
-        Self(public_key, bucket_name.to_string())
+    pub fn new(bucket_name: &str, public_key: PublicKey) -> Self {
+        Self(bucket_name.to_string(), public_key)
     }
 
     pub fn public_key(&self) -> PublicKey {
-        self.0
+        self.1
     }
 
     pub fn bucket_name(&self) -> Bucket {
-        self.1.clone()
+        self.0.clone()
     }
 
     pub fn is_owner(&self, public_key: &PublicKey) -> bool {
-        &self.0 == public_key
+        &self.1 == public_key
     }
 }
 
 impl fmt::Display for ScopedBucket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}{}", self.0, KEY_PREFIX_TOKEN, self.bucket_name())
+        write!(
+            f,
+            "{}{}{}",
+            self.bucket_name(),
+            KEY_PREFIX_TOKEN,
+            self.public_key()
+        )
     }
 }
 
@@ -52,10 +58,10 @@ impl FromStr for ScopedBucket {
             );
         }
 
-        let public_key = PublicKey::from_str(parts[0])
+        let public_key = PublicKey::from_str(parts[1])
             .map_err(|err| anyhow!("invalid public key in rhio subject: {err}"))?;
 
-        Ok(Self(public_key, parts[1].to_string()))
+        Ok(Self(parts[0].to_string(), public_key))
     }
 }
 

--- a/rhio-core/src/lib.rs
+++ b/rhio-core/src/lib.rs
@@ -3,7 +3,7 @@ pub mod message;
 pub mod private_key;
 pub mod subject;
 
-pub use bucket::{Bucket, ScopedBucket};
+pub use bucket::ScopedBucket;
 pub use message::NetworkMessage;
 pub use private_key::load_private_key_from_file;
 pub use subject::{ScopedSubject, Subject};

--- a/rhio-core/src/message.rs
+++ b/rhio-core/src/message.rs
@@ -57,7 +57,7 @@ impl NetworkMessage {
         self.signature = Some(signature);
     }
 
-    pub fn verify(&mut self, public_key: &PublicKey) -> bool {
+    pub fn verify(&self, public_key: &PublicKey) -> bool {
         match &self.signature {
             Some(signature) => {
                 let mut header = self.clone();

--- a/rhio-core/src/message.rs
+++ b/rhio-core/src/message.rs
@@ -82,8 +82,8 @@ mod tests {
         let public_key = private_key.public_key();
         let mut header = NetworkMessage {
             payload: NetworkPayload::BlobAnnouncement(ScopedBucket::new(
-                public_key,
                 "my_bucket".into(),
+                public_key,
             )),
             signature: None,
         };

--- a/rhio/Cargo.toml
+++ b/rhio/Cargo.toml
@@ -10,7 +10,6 @@ name = "rhio"
 [dependencies]
 anyhow = "1.0.86"
 async-nats = "0.37.0"
-async-stream = "0.3.5"
 async-trait = "0.1.83"
 ciborium = "0.2.2"
 clap = { version = "4.5.8", features = ["derive"] }
@@ -26,6 +25,7 @@ p2panda-net = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f807
 p2panda-store = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f807d800c79a3caa5d918b99d83f6e0cce9" }
 p2panda-sync = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f807d800c79a3caa5d918b99d83f6e0cce9" }
 rand = "0.8.5"
+rhio-blobs = { path = "../rhio-blobs" }
 rhio-core = { path = "../rhio-core" }
 rust-s3 = "0.34.0"
 serde = { version = "1.0.203", features = ["derive"] }

--- a/rhio/Cargo.toml
+++ b/rhio/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "rhio"
 name = "rhio"
 
 [dependencies]
-anyhow = "1.0.86"
+anyhow = "1.0.93"
 async-nats = "0.37.0"
 async-trait = "0.1.83"
 ciborium = "0.2.2"
@@ -27,9 +27,9 @@ p2panda-sync = { git = "https://github.com/p2panda/p2panda.git", rev = "14e45f80
 rand = "0.8.5"
 rhio-blobs = { path = "../rhio-blobs" }
 rhio-core = { path = "../rhio-core" }
-rust-s3 = "0.34.0"
-serde = { version = "1.0.203", features = ["derive"] }
-tokio = "1.38.0"
+rust-s3 = "0.35.1"
+serde = { version = "1.0.209", features = ["derive"] }
+tokio = "1.41.1"
 tokio-stream = "0.1.15"
 tokio-util = "0.7.11"
 tracing = "0.1.40"

--- a/rhio/src/blobs/actor.rs
+++ b/rhio/src/blobs/actor.rs
@@ -5,24 +5,22 @@ use iroh_blobs::store::bao_tree::io::fsm::AsyncSliceReader;
 use iroh_blobs::store::{MapEntry, Store};
 use p2panda_blobs::{Blobs as BlobsHandler, DownloadBlobEvent, ImportBlobEvent};
 use p2panda_core::Hash;
+use rhio_blobs::S3Store;
 use s3::creds::Credentials;
+use s3::error::S3Error;
 use s3::{Bucket, BucketConfiguration, Region};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
-use tracing::error;
+use tracing::{debug, error};
 
+use crate::blobs::watcher::S3Event;
 use crate::topic::Query;
 
 pub enum ToBlobsActor {
-    ImportFile {
-        file_path: PathBuf,
-        reply: oneshot::Sender<Result<Hash>>,
-    },
-    ExportBlobMinio {
-        hash: Hash,
+    ImportS3Object {
         bucket_name: String,
-        region: Region,
-        credentials: Credentials,
+        key: String,
+        size: u64,
         reply: oneshot::Sender<Result<()>>,
     },
     DownloadBlob {
@@ -34,25 +32,28 @@ pub enum ToBlobsActor {
     },
 }
 
-pub struct BlobsActor<S>
-where
-    S: Store,
-{
+pub struct BlobsActor {
+    store: S3Store,
     inbox: mpsc::Receiver<ToBlobsActor>,
-    blobs: BlobsHandler<Query, S>,
+    blobs: BlobsHandler<Query, S3Store>,
 }
 
-impl<S> BlobsActor<S>
-where
-    S: Store,
-{
-    pub fn new(blobs: BlobsHandler<Query, S>, inbox: mpsc::Receiver<ToBlobsActor>) -> Self {
-        Self { inbox, blobs }
+impl BlobsActor {
+    pub fn new(
+        store: S3Store,
+        blobs: BlobsHandler<Query, S3Store>,
+        inbox: mpsc::Receiver<ToBlobsActor>,
+    ) -> Self {
+        Self {
+            store,
+            inbox,
+            blobs,
+        }
     }
 
     pub async fn run(mut self) -> Result<()> {
         // Take oneshot sender from external API awaited by `shutdown` call and fire it as soon as
-        // shutdown completed
+        // shutdown completed.
         let shutdown_completed_signal = self.run_inner().await;
         if let Err(err) = self.shutdown().await {
             error!(?err, "error during shutdown");
@@ -70,6 +71,7 @@ where
     async fn run_inner(&mut self) -> Result<oneshot::Sender<()>> {
         loop {
             tokio::select! {
+                biased;
                 Some(msg) = self.inbox.recv() => {
                     match msg {
                         ToBlobsActor::Shutdown { reply } => {
@@ -94,24 +96,17 @@ where
 
     async fn on_actor_message(&mut self, msg: ToBlobsActor) -> Result<()> {
         match msg {
-            ToBlobsActor::ImportFile { file_path, reply } => {
-                let result = self.on_import_file(file_path).await;
+            ToBlobsActor::ImportS3Object {
+                bucket_name,
+                key,
+                size,
+                reply,
+            } => {
+                let result = self.store.import_object(&bucket_name, key, size).await;
                 reply.send(result).ok();
             }
             ToBlobsActor::DownloadBlob { hash, reply } => {
                 let result = self.on_download_blob(hash).await;
-                reply.send(result).ok();
-            }
-            ToBlobsActor::ExportBlobMinio {
-                hash,
-                bucket_name,
-                region,
-                credentials,
-                reply,
-            } => {
-                let result = self
-                    .on_export_blob_minio(hash, bucket_name.clone(), region, credentials)
-                    .await;
                 reply.send(result).ok();
             }
             ToBlobsActor::Shutdown { .. } => {
@@ -120,29 +115,6 @@ where
         }
 
         Ok(())
-    }
-
-    async fn on_import_file(&mut self, path: PathBuf) -> Result<Hash> {
-        let mut stream = Box::pin(self.blobs.import_blob(path.to_path_buf()).await);
-
-        // @TODO(adz): Yes, we know this never loops as all enum cases are currently terminating,
-        // but as soon as we're adding more to `p2panda-blobs` this code becomes crucial.
-        #[allow(clippy::never_loop)]
-        let hash = loop {
-            match stream.next().await {
-                Some(ImportBlobEvent::Done(hash)) => {
-                    break Ok(hash);
-                }
-                Some(ImportBlobEvent::Abort(err)) => {
-                    break Err(anyhow!("failed importing blob: {err}"));
-                }
-                None => {
-                    break Err(anyhow!("failed importing blob"));
-                }
-            }
-        }?;
-
-        Ok(hash)
     }
 
     async fn on_download_blob(&mut self, hash: Hash) -> Result<()> {
@@ -155,69 +127,6 @@ where
                 DownloadBlobEvent::Done => (),
             }
         }
-        Ok(())
-    }
-
-    async fn on_export_blob_minio(
-        &mut self,
-        hash: Hash,
-        bucket_name: String,
-        region: Region,
-        credentials: Credentials,
-    ) -> Result<()> {
-        let entry = self
-            .blobs
-            .get(hash)
-            .await?
-            .ok_or(anyhow!("requested blob hash was not found in blob store"))?;
-
-        // Initiate the minio bucket
-        let mut bucket =
-            Bucket::new(&bucket_name, region.clone(), credentials.clone())?.with_path_style();
-        if !bucket.exists().await? {
-            bucket = Bucket::create_with_path_style(
-                &bucket_name,
-                region,
-                credentials.clone(),
-                BucketConfiguration::default(),
-            )
-            .await?
-            .bucket;
-        };
-
-        // Start a multi-part upload
-        let mut parts = Vec::new();
-        let mpu = bucket
-            .initiate_multipart_upload(&hash.to_string(), "application/octet-stream")
-            .await?;
-
-        // Access the actual blob data and iterate over it's bytes in chunks
-        let mut reader = entry.data_reader().await?;
-        let size = reader.size().await?;
-        for (index, offset) in (0..size).step_by(5 * 1024 * 1024).enumerate() {
-            // Upload this chunk to the minio bucket
-            let bytes = reader.read_at(offset, 5 * 1024 * 1024).await?;
-            let part = bucket
-                .put_multipart_chunk(
-                    bytes.to_vec(),
-                    &hash.to_string(),
-                    { index + 1 } as u32,
-                    &mpu.upload_id,
-                    "application/octet-stream",
-                )
-                .await?;
-            parts.push(part);
-        }
-
-        let response = bucket
-            .complete_multipart_upload(&hash.to_string(), &mpu.upload_id, parts)
-            .await?;
-
-        if response.status_code() != 200 {
-            error!("uploading blob to minio bucket failed with: {response}");
-            return Err(anyhow!(response));
-        }
-
         Ok(())
     }
 

--- a/rhio/src/blobs/mod.rs
+++ b/rhio/src/blobs/mod.rs
@@ -106,7 +106,7 @@ impl Blobs {
 
 /// Initiates and returns a blob store handler for S3 backends based on the rhio config.
 pub async fn store_from_config(config: &Config) -> Result<S3Store> {
-    let mut buckets: HashMap<String, Box<Bucket>> = HashMap::new();
+    let mut buckets: HashMap<String, Bucket> = HashMap::new();
 
     let credentials = config
         .s3
@@ -125,7 +125,7 @@ pub async fn store_from_config(config: &Config) -> Result<S3Store> {
         for bucket_name in &publish.s3_buckets {
             let bucket =
                 Bucket::new(bucket_name, region.clone(), credentials.clone())?.with_path_style();
-            buckets.insert(bucket_name.clone(), bucket);
+            buckets.insert(bucket_name.clone(), *bucket);
         }
     }
 
@@ -134,11 +134,11 @@ pub async fn store_from_config(config: &Config) -> Result<S3Store> {
             let bucket_name = scoped_bucket.bucket_name();
             let bucket =
                 Bucket::new(&bucket_name, region.clone(), credentials.clone())?.with_path_style();
-            buckets.insert(bucket_name, bucket);
+            buckets.insert(bucket_name, *bucket);
         }
     }
 
-    let buckets: Vec<Box<Bucket>> = buckets.values().cloned().collect();
+    let buckets: Vec<Bucket> = buckets.values().cloned().collect();
     let store = S3Store::new(buckets)
         .await
         .context("could not initialize s3 interface")?;

--- a/rhio/src/blobs/mod.rs
+++ b/rhio/src/blobs/mod.rs
@@ -88,7 +88,7 @@ impl Blobs {
     pub async fn download(
         &self,
         hash: BlobHash,
-        bucket: ScopedBucket,
+        bucket_name: BucketName,
         key: ObjectKey,
         size: ObjectSize,
     ) -> Result<()> {
@@ -96,7 +96,7 @@ impl Blobs {
         self.blobs_actor_tx
             .send(ToBlobsActor::DownloadBlob {
                 hash,
-                bucket,
+                bucket_name,
                 key,
                 size,
                 reply,

--- a/rhio/src/blobs/watcher.rs
+++ b/rhio/src/blobs/watcher.rs
@@ -2,21 +2,14 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-use iroh_blobs::Hash as BlobsHash;
 use rhio_blobs::paths::{META_SUFFIX, NO_PREFIX, OUTBOARD_SUFFIX};
-use rhio_blobs::S3Store;
+use rhio_blobs::{BlobHash, BucketName, ObjectKey, ObjectSize, S3Store};
 use s3::error::S3Error;
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio_util::task::LocalPoolHandle;
 use tracing::debug;
 
 const POLL_FREQUENCY: Duration = Duration::from_secs(1);
-
-type ObjectSize = u64;
-
-type ObjectKey = String;
-
-type BucketName = String;
 
 /// Service watching the S3 buckets and p2p blob interface to inform us on newly detected objects
 /// and their import status.
@@ -51,7 +44,7 @@ impl std::hash::Hash for WatchedObject {
 #[derive(Clone, Debug)]
 enum ImportState {
     NotImported,
-    Imported(BlobsHash),
+    Imported(BlobHash),
 }
 
 #[derive(Debug)]
@@ -224,6 +217,6 @@ impl S3Watcher {
 #[derive(Clone, Debug)]
 pub enum S3Event {
     DetectedS3Object(BucketName, ObjectSize, ObjectKey),
-    BlobImportFinished(BucketName, BlobsHash, ObjectSize, ObjectKey),
-    DetectedIncompleteBlob(BucketName, BlobsHash, ObjectSize, ObjectKey),
+    BlobImportFinished(BucketName, BlobHash, ObjectSize, ObjectKey),
+    DetectedIncompleteBlob(BucketName, BlobHash, ObjectSize, ObjectKey),
 }

--- a/rhio/src/blobs/watcher.rs
+++ b/rhio/src/blobs/watcher.rs
@@ -139,10 +139,10 @@ impl S3Watcher {
                                 debug!(key = %path.data(), size = %size, hash = %hash, "detected finished blob import");
                                 if event_tx
                                     .send(Ok(S3Event::BlobImportFinished(
-                                        bucket_name.clone(),
                                         hash,
-                                        size,
+                                        bucket_name.clone(),
                                         path.data(),
+                                        size,
                                     )))
                                     .await
                                     .is_err()
@@ -160,8 +160,8 @@ impl S3Watcher {
                                 if event_tx
                                     .send(Ok(S3Event::DetectedS3Object(
                                         bucket_name.clone(),
-                                        object.size,
                                         object.key,
+                                        object.size,
                                     )))
                                     .await
                                     .is_err()
@@ -187,10 +187,10 @@ impl S3Watcher {
                                 debug!(key = %path.data(), size = %size, hash = %hash, "detected incomplete blob download");
                                 if event_tx
                                     .send(Ok(S3Event::DetectedIncompleteBlob(
-                                        bucket_name.clone(),
                                         hash,
-                                        size,
+                                        bucket_name.clone(),
                                         path.data(),
+                                        size,
                                     )))
                                     .await
                                     .is_err()
@@ -216,7 +216,7 @@ impl S3Watcher {
 
 #[derive(Clone, Debug)]
 pub enum S3Event {
-    DetectedS3Object(BucketName, ObjectSize, ObjectKey),
-    BlobImportFinished(BucketName, BlobHash, ObjectSize, ObjectKey),
-    DetectedIncompleteBlob(BucketName, BlobHash, ObjectSize, ObjectKey),
+    DetectedS3Object(BucketName, ObjectKey, ObjectSize),
+    BlobImportFinished(BlobHash, BucketName, ObjectKey, ObjectSize),
+    DetectedIncompleteBlob(BlobHash, BucketName, ObjectKey, ObjectSize),
 }

--- a/rhio/src/blobs/watcher.rs
+++ b/rhio/src/blobs/watcher.rs
@@ -131,7 +131,7 @@ impl S3Watcher {
                             // as soon as a new object was completed.
                             if is_new && !first_run {
                                 debug!(key = %path.data(), size = %size, hash = %hash, "detected newly completed S3 object");
-                                event_tx.send(S3WatcherEvent::ShareableBlobDetected(
+                                event_tx.send(S3WatcherEvent::BlobImportFinished(
                                     hash,
                                     size,
                                     path.data(),
@@ -144,7 +144,7 @@ impl S3Watcher {
                         for object in maybe_to_be_imported {
                             if !inner.completed.contains(&object) {
                                 debug!(key = %object.key, size = %object.size, "detected new S3 object, needs to be imported");
-                                event_tx.send(S3WatcherEvent::NewLocalBlobDetected(
+                                event_tx.send(S3WatcherEvent::DetectedS3Object(
                                     object.size,
                                     object.key,
                                 ));
@@ -165,7 +165,7 @@ impl S3Watcher {
                             });
                             if is_new {
                                 debug!(key = %path.data(), size = %size, hash = %hash, "detected incomplete S3 object, download needs to be resumed");
-                                event_tx.send(S3WatcherEvent::IncompleteBlobDetected(
+                                event_tx.send(S3WatcherEvent::DetectedIncompleteBlob(
                                     hash,
                                     size,
                                     path.data(),
@@ -193,7 +193,7 @@ impl S3Watcher {
 
 #[derive(Clone, Debug)]
 pub enum S3WatcherEvent {
-    NewLocalBlobDetected(u64, String),
-    ShareableBlobDetected(BlobsHash, u64, String),
-    IncompleteBlobDetected(BlobsHash, u64, String),
+    DetectedS3Object(u64, String),
+    BlobImportFinished(BlobsHash, u64, String),
+    DetectedIncompleteBlob(BlobsHash, u64, String),
 }

--- a/rhio/src/blobs/watcher.rs
+++ b/rhio/src/blobs/watcher.rs
@@ -2,8 +2,9 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-use rhio_blobs::paths::{META_SUFFIX, NO_PREFIX, OUTBOARD_SUFFIX};
-use rhio_blobs::{BlobHash, BucketName, ObjectKey, ObjectSize, S3Store};
+use rhio_blobs::{
+    BlobHash, BucketName, ObjectKey, ObjectSize, S3Store, META_SUFFIX, NO_PREFIX, OUTBOARD_SUFFIX,
+};
 use s3::error::S3Error;
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio_util::task::LocalPoolHandle;

--- a/rhio/src/blobs/watcher.rs
+++ b/rhio/src/blobs/watcher.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+use rhio_blobs::S3Store;
+use tokio::sync::broadcast;
+
+#[derive(Clone, Debug)]
+pub enum S3WatcherEvent {}
+
+const POLL_FREQUENCY: Duration = Duration::from_secs(1);
+
+/// Service watching the S3 buckets and p2p blob interface to inform us on newly detected objects.
+#[derive(Debug)]
+pub struct S3Watcher {
+    event_tx: broadcast::Sender<S3WatcherEvent>,
+}
+
+impl S3Watcher {
+    pub fn new(store: S3Store) -> Self {
+        let (event_tx, _) = broadcast::channel(64);
+        let watcher = Self { event_tx };
+
+        tokio::spawn(async move {
+            loop {
+                for bucket in store.buckets() {
+                    println!("CHECK LIST for {}", bucket.name());
+
+                    let list_results = bucket.list("/".to_owned(), None).await.unwrap();
+                    for list in list_results {
+                        for object in list.contents {
+                            println!("{:?}", object);
+                        }
+                    }
+                }
+
+                tokio::time::sleep(POLL_FREQUENCY).await;
+            }
+        });
+
+        watcher
+    }
+
+    pub fn subscribe(&mut self) -> broadcast::Receiver<S3WatcherEvent> {
+        self.event_tx.subscribe()
+    }
+}

--- a/rhio/src/blobs/watcher.rs
+++ b/rhio/src/blobs/watcher.rs
@@ -125,7 +125,7 @@ impl S3Watcher {
                     {
                         let list = store.complete_blobs().await;
                         let mut inner = inner.write().await;
-                        for (hash, path, size) in list {
+                        for (hash, _, path, size) in list {
                             let is_new = inner.completed.insert(WatchedObject {
                                 size,
                                 key: path.data(),
@@ -177,7 +177,7 @@ impl S3Watcher {
                     {
                         let list = store.incomplete_blobs().await;
                         let mut inner = inner.write().await;
-                        for (hash, path, size) in list {
+                        for (hash, _, path, size) in list {
                             let is_new = inner.incomplete.insert(WatchedObject {
                                 size,
                                 key: path.data(),

--- a/rhio/src/blobs/watcher.rs
+++ b/rhio/src/blobs/watcher.rs
@@ -1,39 +1,155 @@
-use std::time::Duration;
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
+use iroh_blobs::Hash as BlobsHash;
 use rhio_blobs::S3Store;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, RwLock};
+use tracing::debug;
 
 #[derive(Clone, Debug)]
 pub enum S3WatcherEvent {}
 
 const POLL_FREQUENCY: Duration = Duration::from_secs(1);
 
+const NO_PREFIX: String = String::new(); // Empty string.
+
 /// Service watching the S3 buckets and p2p blob interface to inform us on newly detected objects.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct S3Watcher {
     event_tx: broadcast::Sender<S3WatcherEvent>,
+    inner: Arc<RwLock<Inner>>,
+}
+
+#[derive(Clone, Debug)]
+struct WatcherObject {
+    pub size: u64,
+    pub key: String,
+    pub hash: Option<BlobsHash>,
+}
+
+impl PartialEq for WatcherObject {
+    fn eq(&self, other: &Self) -> bool {
+        self.size == other.size && self.key == other.key
+    }
+}
+
+impl Eq for WatcherObject {}
+
+impl std::hash::Hash for WatcherObject {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.size.hash(state);
+        self.key.hash(state);
+    }
+}
+
+#[derive(Debug)]
+struct Inner {
+    s3_objects: HashSet<WatcherObject>,
+    completed: HashSet<WatcherObject>,
+    incomplete: HashSet<WatcherObject>,
 }
 
 impl S3Watcher {
     pub fn new(store: S3Store) -> Self {
         let (event_tx, _) = broadcast::channel(64);
-        let watcher = Self { event_tx };
+
+        let inner = Arc::new(RwLock::new(Inner {
+            s3_objects: HashSet::new(),
+            completed: HashSet::new(),
+            incomplete: HashSet::new(),
+        }));
+
+        let watcher = Self {
+            event_tx,
+            inner: inner.clone(),
+        };
 
         tokio::spawn(async move {
+            let mut first_run = true;
+
             loop {
                 for bucket in store.buckets() {
-                    println!("CHECK LIST for {}", bucket.name());
+                    // 1. List of _all_ S3 objects in this bucket.
+                    let mut maybe_to_be_imported = Vec::new();
+                    match bucket.list(NO_PREFIX, Some("/".to_string())).await {
+                        Ok(pages) => {
+                            let mut inner = inner.write().await;
+                            for page in pages {
+                                for object in page.contents {
+                                    let item = WatcherObject {
+                                        size: object.size,
+                                        key: object.key,
+                                        hash: None,
+                                    };
 
-                    let list_results = bucket.list("/".to_owned(), None).await.unwrap();
-                    for list in list_results {
-                        for object in list.contents {
-                            println!("{:?}", object);
+                                    let is_new = inner.s3_objects.insert(item.clone());
+                                    if is_new {
+                                        maybe_to_be_imported.push(item);
+                                    }
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            // @TODO: Send critical error over channel.
+                            return Err(err);
+                        }
+                    }
+
+                    // 2. List of S3 objects which have been encoded / completed already and are
+                    //    ready for p2p sync.
+                    {
+                        let list = store.complete_blobs().await;
+                        let mut inner = inner.write().await;
+                        for (hash, path, size) in list {
+                            let is_new = inner.completed.insert(WatcherObject {
+                                size,
+                                key: path.data(),
+                                hash: Some(hash),
+                            });
+
+                            // During the first iteration we're only establishing the initial state
+                            // of completed items. For all further iterations we're sending events
+                            // as soon as a new object was completed.
+                            if is_new && !first_run {
+                                debug!(key = %path.data(), size = %size, hash = %hash, "detected newly completed S3 object");
+                                // @TODO: Send event, this object was just completed.
+                            }
+                        }
+
+                        // Compare item from S3 database with completed ones, so we can identify
+                        // which object has not yet been imported.
+                        for object in maybe_to_be_imported {
+                            if !inner.completed.contains(&object) {
+                                debug!(key = %object.key, size = %object.size, "detected new S3 object, needs to be imported");
+                                // @TODO: Send event, this object has not yet been imported!
+                            }
+                        }
+                    }
+
+                    // 3. List of S3 objects which were started to be downloaded, but did not
+                    //    finish yet.
+                    {
+                        let list = store.incomplete_blobs().await;
+                        let mut inner = inner.write().await;
+                        for (hash, path, size) in list {
+                            let is_new = inner.incomplete.insert(WatcherObject {
+                                size,
+                                key: path.data(),
+                                hash: Some(hash),
+                            });
+                            if is_new {
+                                debug!(key = %path.data(), size = %size, hash = %hash, "detected incomplete S3 object, download needs to be resumed");
+                                // @TODO: Send event, this download needs to be resumed
+                            }
                         }
                     }
                 }
 
                 tokio::time::sleep(POLL_FREQUENCY).await;
+
+                first_run = false;
             }
+
+            Ok(())
         });
 
         watcher

--- a/rhio/src/config.rs
+++ b/rhio/src/config.rs
@@ -7,7 +7,8 @@ use directories::ProjectDirs;
 use figment::providers::{Env, Format, Serialized, Yaml};
 use figment::Figment;
 use p2panda_core::PublicKey;
-use rhio_core::{Bucket, ScopedBucket, ScopedSubject};
+use rhio_blobs::BucketName;
+use rhio_core::{ScopedBucket, ScopedSubject};
 use s3::creds::Credentials;
 use serde::{Deserialize, Serialize};
 
@@ -209,7 +210,7 @@ pub struct KnownNode {
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PublishConfig {
     #[serde(default)]
-    pub s3_buckets: Vec<Bucket>,
+    pub s3_buckets: Vec<BucketName>,
     #[serde(default)]
     pub nats_subjects: Vec<NatsSubject>,
 }

--- a/rhio/src/config.rs
+++ b/rhio/src/config.rs
@@ -275,8 +275,8 @@ nodes:
 
 publish:
     s3_buckets:
-        - "local_bucket_1"
-        - "local_bucket_2"
+        - "local-bucket-1"
+        - "local-bucket-2"
     nats_subjects:
         - subject: "8e0d63ef8b499503d541132b798beb718f763a61f0334262206be097c8db106e.workload.berlin.energy"
           stream: "workload"
@@ -285,8 +285,8 @@ publish:
 
 subscribe:
     s3_buckets:
-      - "6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a/remote_bucket_1"
-      - "6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a/remote_bucket_2"
+      - "remote-bucket-1/6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a"
+      - "remote-bucket-2/6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a"
     nats_subjects:
       - subject: "6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a.workload.*.energy"
         stream: "workload"
@@ -342,7 +342,7 @@ subscribe:
                     },
                     log_level: None,
                     publish: Some(PublishConfig {
-                        s3_buckets: vec!["local_bucket_1".into(), "local_bucket_2".into()],
+                        s3_buckets: vec!["local-bucket-1".into(), "local-bucket-2".into()],
                         nats_subjects: vec![
                             NatsSubject {
                                 stream_name: "workload".into(),
@@ -356,10 +356,10 @@ subscribe:
                     }),
                     subscribe: Some(SubscribeConfig {
                         s3_buckets: vec![
-                            "6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a/remote_bucket_1"
+                            "remote-bucket-1/6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a"
                                 .parse()
                                 .unwrap(),
-                            "6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a/remote_bucket_2"
+                            "remote-bucket-2/6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a"
                                 .parse()
                                 .unwrap(),
                         ],

--- a/rhio/src/network/mod.rs
+++ b/rhio/src/network/mod.rs
@@ -4,6 +4,7 @@ pub mod sync;
 use anyhow::Result;
 use futures_util::future::{MapErr, Shared};
 use futures_util::{FutureExt, TryFutureExt};
+use p2panda_core::PublicKey;
 use p2panda_net::network::FromNetwork;
 use p2panda_net::Network;
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -17,6 +18,7 @@ use crate::JoinErrToStr;
 
 #[derive(Debug)]
 pub struct Panda {
+    pub node_id: PublicKey,
     panda_actor_tx: mpsc::Sender<ToPandaActor>,
     #[allow(dead_code)]
     actor_handle: Shared<MapErr<AbortOnDropHandle<()>, JoinErrToStr>>,
@@ -24,6 +26,8 @@ pub struct Panda {
 
 impl Panda {
     pub fn new(network: Network<Query>) -> Self {
+        let node_id = network.node_id();
+
         let (panda_actor_tx, panda_actor_rx) = mpsc::channel(256);
         let panda_actor = PandaActor::new(network, panda_actor_rx);
 
@@ -38,6 +42,7 @@ impl Panda {
             .shared();
 
         Self {
+            node_id,
             panda_actor_tx,
             actor_handle: actor_drop_handle,
         }

--- a/rhio/src/network/mod.rs
+++ b/rhio/src/network/mod.rs
@@ -4,7 +4,6 @@ pub mod sync;
 use anyhow::Result;
 use futures_util::future::{MapErr, Shared};
 use futures_util::{FutureExt, TryFutureExt};
-use p2panda_core::PublicKey;
 use p2panda_net::network::FromNetwork;
 use p2panda_net::Network;
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -18,7 +17,6 @@ use crate::JoinErrToStr;
 
 #[derive(Debug)]
 pub struct Panda {
-    pub node_id: PublicKey,
     panda_actor_tx: mpsc::Sender<ToPandaActor>,
     #[allow(dead_code)]
     actor_handle: Shared<MapErr<AbortOnDropHandle<()>, JoinErrToStr>>,
@@ -26,8 +24,6 @@ pub struct Panda {
 
 impl Panda {
     pub fn new(network: Network<Query>) -> Self {
-        let node_id = network.node_id();
-
         let (panda_actor_tx, panda_actor_rx) = mpsc::channel(256);
         let panda_actor = PandaActor::new(network, panda_actor_rx);
 
@@ -42,7 +38,6 @@ impl Panda {
             .shared();
 
         Self {
-            node_id,
             panda_actor_tx,
             actor_handle: actor_drop_handle,
         }

--- a/rhio/src/network/sync.rs
+++ b/rhio/src/network/sync.rs
@@ -29,6 +29,13 @@ pub enum Message {
     Blobs(Vec<NetworkMessage>),
 }
 
+/// Simple sync protocol implementation to allow exchange of past NATS messages or blob
+/// announcements.
+// @TODO(adz): This implementation is sub-optimal as it requires the peers to send over
+// _everything_ they know about. This can be optimized later with a smarter set reconciliation
+// strategy though it'll be tricky to find out how to organize the data to make it more efficient
+// (NATS messages do not have timestamps but we could sort them by sequential order of the filtered
+// consumer, blobs could be sorted by S3 key (the absolute path)?).
 #[derive(Clone, Debug)]
 pub struct RhioSyncProtocol {
     config: Config,

--- a/rhio/src/network/sync.rs
+++ b/rhio/src/network/sync.rs
@@ -10,6 +10,7 @@ use p2panda_core::{Hash, PrivateKey};
 use p2panda_net::TopicId;
 use p2panda_sync::cbor::{into_cbor_sink, into_cbor_stream};
 use p2panda_sync::{FromSync, SyncError, SyncProtocol};
+use rhio_blobs::{BlobHash, BucketName, ObjectSize, Paths, S3Store};
 use rhio_core::{NetworkMessage, ScopedSubject};
 use serde::{Deserialize, Serialize};
 use tokio_stream::wrappers::BroadcastStream;
@@ -24,12 +25,15 @@ pub enum Message {
     Query(Query),
     NatsHave(Vec<Hash>),
     NatsMessages(Vec<NetworkMessage>),
+    BlobsHave(Vec<BlobHash>),
+    Blobs(Vec<NetworkMessage>),
 }
 
 #[derive(Clone, Debug)]
 pub struct RhioSyncProtocol {
     config: Config,
     nats: Nats,
+    blob_store: S3Store,
     private_key: PrivateKey,
 }
 
@@ -71,7 +75,36 @@ impl<'a> SyncProtocol<'a, Query> for RhioSyncProtocol {
         // 2. We can sync over NATS messages or S3 blob announcements.
         match query {
             Query::Bucket { ref bucket } => {
-                // @TODO
+                // Send over a list of blob hashes we have already to remote peer.
+                let blob_hashes: Vec<BlobHash> = self
+                    .complete_blobs(&bucket.bucket_name())
+                    .await
+                    .iter()
+                    .map(|(hash, _, _, _)| hash.to_owned())
+                    .collect();
+                debug!(parent: &span, "we have {} completed blobs", blob_hashes.len());
+                sink.send(Message::BlobsHave(blob_hashes)).await?;
+
+                // Wait for other peer to send us what we're missing.
+                let message = stream.next().await.ok_or(SyncError::UnexpectedBehaviour(
+                    "incoming message stream ended prematurely".into(),
+                ))??;
+                let Message::Blobs(remote_blob_announcements) = message else {
+                    return Err(SyncError::UnexpectedBehaviour(
+                        "did not receive expected message".into(),
+                    ));
+                };
+
+                debug!(parent: &span,
+                    "received {} new blob announcements from remote peer",
+                    remote_blob_announcements.len()
+                );
+
+                for blob_announcement in remote_blob_announcements {
+                    app_tx
+                        .send(FromSync::Data(blob_announcement.to_bytes(), None))
+                        .await?;
+                }
             }
             Query::Subject { ref subject } => {
                 // NATS streams are configured locally for every peer, so we need to look it up
@@ -186,7 +219,61 @@ impl<'a> SyncProtocol<'a, Query> for RhioSyncProtocol {
         // 2. We can sync over NATS messages or S3 blob announcements.
         match &query {
             Query::Bucket { bucket } => {
-                // @TODO
+                // Await message from other peer on the blobs they _have_, so we can calculate what
+                // they're missing and send that delta to them.
+                let message = stream.next().await.ok_or(SyncError::UnexpectedBehaviour(
+                    "incoming message stream ended prematurely".into(),
+                ))??;
+                let Message::BlobsHave(remote_blob_hashes) = message else {
+                    return Err(SyncError::UnexpectedBehaviour(
+                        "did not receive expected message".into(),
+                    ));
+                };
+
+                let is_publishing = match &self.config.publish {
+                    Some(publications) => publications
+                        .s3_buckets
+                        .iter()
+                        .find(|bucket_name| &&bucket.bucket_name() == bucket_name),
+                    None => None,
+                }
+                .is_some();
+
+                if !is_publishing {
+                    // Inform the other peer politely that we need to end here as we can't provide for
+                    // this S3 bucket by sending them an empty array back.
+                    debug!(parent: &span,
+                        "can't provide data, politely send empty array back",
+                    );
+                    sink.send(Message::Blobs(vec![])).await?;
+                    return Ok(());
+                }
+
+                let blob_announcements: Vec<NetworkMessage> = self
+                    .complete_blobs(&bucket.bucket_name())
+                    .await
+                    .into_iter()
+                    .filter_map(|(hash, _, paths, size)| {
+                        if remote_blob_hashes.contains(&hash) {
+                            None
+                        } else {
+                            Some({
+                                let mut signed_msg = NetworkMessage::new_blob_announcement(
+                                    hash,
+                                    bucket.clone(),
+                                    paths.data(),
+                                    size,
+                                );
+                                signed_msg.sign(&self.private_key);
+                                signed_msg
+                            })
+                        }
+                    })
+                    .collect();
+
+                debug!(parent: &span, "send {} blob announcements", blob_announcements.len());
+
+                sink.send(Message::Blobs(blob_announcements)).await?;
             }
             Query::Subject { subject } => {
                 // Look up our config to find out if we have a NATS stream somewhere which fits the
@@ -276,12 +363,26 @@ impl<'a> SyncProtocol<'a, Query> for RhioSyncProtocol {
 }
 
 impl RhioSyncProtocol {
-    pub fn new(config: Config, nats: Nats, private_key: PrivateKey) -> Self {
+    pub fn new(config: Config, nats: Nats, blob_store: S3Store, private_key: PrivateKey) -> Self {
         Self {
             config,
             nats,
+            blob_store,
             private_key,
         }
+    }
+
+    /// Get a list of blobs we have ourselves already in the blob store for this query.
+    async fn complete_blobs(
+        &self,
+        bucket_name: &BucketName,
+    ) -> Vec<(BlobHash, BucketName, Paths, ObjectSize)> {
+        self.blob_store
+            .complete_blobs()
+            .await
+            .into_iter()
+            .filter(|(_, store_bucket_name, _, _)| store_bucket_name == bucket_name)
+            .collect()
     }
 
     /// Download all NATS messages we have for that subject and return them as a stream.

--- a/rhio/src/network/sync.rs
+++ b/rhio/src/network/sync.rs
@@ -70,7 +70,9 @@ impl<'a> SyncProtocol<'a, Query> for RhioSyncProtocol {
 
         // 2. We can sync over NATS messages or S3 blob announcements.
         match query {
-            Query::Bucket { .. } => todo!(),
+            Query::Bucket { ref bucket } => {
+                // @TODO
+            }
             Query::Subject { ref subject } => {
                 // NATS streams are configured locally for every peer, so we need to look it up
                 // ourselves to find out what stream configuration we have for this subject.
@@ -183,7 +185,9 @@ impl<'a> SyncProtocol<'a, Query> for RhioSyncProtocol {
 
         // 2. We can sync over NATS messages or S3 blob announcements.
         match &query {
-            Query::Bucket { .. } => todo!(),
+            Query::Bucket { bucket } => {
+                // @TODO
+            }
             Query::Subject { subject } => {
                 // Look up our config to find out if we have a NATS stream somewhere which fits the
                 // requested subject.

--- a/rhio/src/network/sync.rs
+++ b/rhio/src/network/sync.rs
@@ -74,7 +74,9 @@ impl<'a> SyncProtocol<'a, Query> for RhioSyncProtocol {
         //
         // The current p2panda API does not give any control to turn off syncing for some data
         // stream subscriptions, this is why we're doing it this hacky way.
-        if matches!(query, Query::NoSyncSubject { .. }) {
+        if matches!(query, Query::NoSyncSubject { .. })
+            || matches!(query, Query::NoSyncBucket { .. })
+        {
             debug!(parent: &span, "end sync session prematurely as we don't want to have one");
             return Ok(());
         }
@@ -174,6 +176,9 @@ impl<'a> SyncProtocol<'a, Query> for RhioSyncProtocol {
                         .await?;
                 }
             }
+            Query::NoSyncBucket { .. } => {
+                unreachable!("returned already earlier on no-sync option")
+            }
             Query::NoSyncSubject { .. } => {
                 unreachable!("returned already earlier on no-sync option")
             }
@@ -218,7 +223,9 @@ impl<'a> SyncProtocol<'a, Query> for RhioSyncProtocol {
         //
         // @TODO(adz): This is a workaround to disable syncing in some cases as the current p2panda
         // API does not give any control to turn off syncing for some topics.
-        if matches!(query, Query::NoSyncSubject { .. }) {
+        if matches!(query, Query::NoSyncSubject { .. })
+            || matches!(query, Query::NoSyncBucket { .. })
+        {
             debug!(parent: &span, "end sync session prematurely as we don't want to have one");
             return Ok(());
         }
@@ -353,6 +360,9 @@ impl<'a> SyncProtocol<'a, Query> for RhioSyncProtocol {
                 debug!(parent: &span, "downloaded {} NATS messages", nats_messages.len());
 
                 sink.send(Message::NatsMessages(nats_messages)).await?;
+            }
+            Query::NoSyncBucket { .. } => {
+                unreachable!("we've already returned before no-sync option")
             }
             Query::NoSyncSubject { .. } => {
                 unreachable!("we've already returned before no-sync option")

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -324,7 +324,13 @@ impl NodeActor {
                 // which is not the right bucket name or not the right author.
                 if is_bucket_matching(&self.subscriptions, bucket) {
                     self.blobs
-                        .download(*hash, bucket.bucket_name(), key.to_owned(), *size)
+                        .download(
+                            *hash,
+                            bucket.bucket_name(),
+                            // Blobs from remote peers are namespaced by their public key.
+                            format!("{}/{}", bucket.public_key(), key),
+                            *size,
+                        )
                         .await?;
                 }
             }

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -305,6 +305,8 @@ impl NodeActor {
         let network_message = NetworkMessage::from_bytes(&bytes)?;
         match network_message.payload {
             NetworkPayload::BlobAnnouncement(hash, bucket, key, size) => {
+                // We're interested in a bucket from a _specific_ public key. Filter out everything
+                // which is not the right bucket name or not the right author.
                 if is_bucket_matching(&self.subscriptions, &bucket) {
                     self.blobs
                         .download(hash, bucket.bucket_name(), key, size)

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -161,8 +161,8 @@ impl NodeActor {
         // @TODO(adz): Doing this via this `NoSync` option is a hacky workaround. See sync
         // implementation for more details.
         let topic_query = match &publication {
-            Publication::Bucket { bucket_name: _ } => Query::NoSyncSubject {
-                public_key: self.panda.node_id,
+            Publication::Bucket { bucket } => Query::NoSyncSubject {
+                public_key: bucket.public_key(),
             },
             Publication::Subject { subject, .. } => Query::NoSyncSubject {
                 public_key: subject.public_key(),
@@ -173,7 +173,7 @@ impl NodeActor {
         let network_rx = self.panda.subscribe(topic_query).await?;
 
         match publication {
-            Publication::Bucket { bucket_name: _ } => {
+            Publication::Bucket { bucket: _ } => {
                 // @TODO
             }
             Publication::Subject {
@@ -320,12 +320,12 @@ impl NodeActor {
             }
             // Blob store finished importing a new S3 object, it is ready now for distribution in
             // the p2p network!
-            S3Event::BlobImportFinished(bucket_name, hash, size, key) => {
+            S3Event::BlobImportFinished(_bucket_name, _hash, _size, _key) => {
                 // @TODO: Announce!
             }
             // We've detected an uncomplete blob, probably the process was exited before the
             // download finished.
-            S3Event::DetectedIncompleteBlob(bucket_name, hash, size, key) => {
+            S3Event::DetectedIncompleteBlob(_bucket_name, _hash, _size, _key) => {
                 // @TODO: Resume download!
             }
         }

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -297,7 +297,10 @@ impl NodeActor {
 
         let network_message = NetworkMessage::from_bytes(&bytes)?;
         match network_message.payload {
-            NetworkPayload::BlobAnnouncement(_scoped_bucket) => todo!(),
+            NetworkPayload::BlobAnnouncement(_scoped_bucket) => {
+                // @TODO: We've received a blob announcement here, check if we're interested in it
+                // and then start download.
+            }
             NetworkPayload::NatsMessage(message) => {
                 // Filter out all incoming messages we're not subscribed to. This can happen
                 // especially when receiving messages over the gossip overlay as they are not

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -392,8 +392,20 @@ fn is_subject_matching(subscriptions: &Vec<Subscription>, incoming: &ScopedSubje
 }
 
 /// Returns true if incoming blob announcement is of interested to our local node.
-#[allow(unused_variables)]
 fn is_bucket_matching(subscriptions: &Vec<Subscription>, incoming: &ScopedBucket) -> bool {
-    // @TODO
+    for subscription in subscriptions {
+        match subscription {
+            Subscription::Bucket { bucket } => {
+                if bucket == incoming {
+                    return true;
+                } else {
+                    continue;
+                }
+            }
+            Subscription::Subject { .. } => {
+                continue;
+            }
+        }
+    }
     false
 }

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -304,18 +304,10 @@ impl NodeActor {
 
         let network_message = NetworkMessage::from_bytes(&bytes)?;
         match network_message.payload {
-            NetworkPayload::BlobAnnouncement(_hash, bucket, _key, _size) => {
-                if !is_bucket_matching(&self.subscriptions, &bucket) {
-                    return Ok(());
+            NetworkPayload::BlobAnnouncement(hash, bucket, key, size) => {
+                if is_bucket_matching(&self.subscriptions, &bucket) {
+                    self.blobs.download(hash, bucket, key, size).await?;
                 }
-
-                // @TODO: We've received a blob announcement here, check if we're interested in it
-                // and then start download. This is a two step process:
-                //
-                // 1. Tell the store about a newly discovered blob using
-                //    store.blob_discovered(hash: Hash, path: String, size: u64)
-                // 2. Tell the blob actor to download this blob from the network, it uses
-                //    Downloader from p2panda-blobs (the downloader has access to the store)
             }
             NetworkPayload::NatsMessage(message) => {
                 // Filter out all incoming messages we're not subscribed to. This can happen

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -375,6 +375,7 @@ fn is_subject_matching(subscriptions: &Vec<Subscription>, incoming: &ScopedSubje
 }
 
 /// Returns true if incoming blob announcement is of interested to our local node.
+#[allow(unused_variables)]
 fn is_bucket_matching(subscriptions: &Vec<Subscription>, incoming: &ScopedBucket) -> bool {
     // @TODO
     false

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -174,7 +174,7 @@ impl NodeActor {
         // @TODO(adz): Doing this via this `NoSync` option is a hacky workaround. See sync
         // implementation for more details.
         let topic_query = match &publication {
-            Publication::Bucket { bucket } => Query::NoSyncSubject {
+            Publication::Bucket { bucket } => Query::NoSyncBucket {
                 public_key: bucket.public_key(),
             },
             Publication::Subject { subject, .. } => Query::NoSyncSubject {

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -42,6 +42,7 @@ pub struct NodeActor {
     nats: Nats,
     panda: Panda,
     blobs: Blobs,
+    #[allow(dead_code)]
     watcher: S3Watcher,
 }
 

--- a/rhio/src/node/mod.rs
+++ b/rhio/src/node/mod.rs
@@ -63,8 +63,9 @@ impl Node {
 
         // 3. Configure and set up S3 store and connection handlers for blob replication.
         let blob_store = store_from_config(&config).await?;
-        let (network, blobs_handler) = BlobsHandler::from_builder(builder, blob_store).await?;
-        let blobs = Blobs::new(config.s3.clone(), blobs_handler);
+        let (network, blobs_handler) =
+            BlobsHandler::from_builder(builder, blob_store.clone()).await?;
+        let blobs = Blobs::new(config.s3.clone(), blob_store, blobs_handler);
 
         // 4. Move all networking logic into dedicated "panda" actor, dealing with p2p networking,
         //    data replication and gossipping.

--- a/rhio/src/node/mod.rs
+++ b/rhio/src/node/mod.rs
@@ -5,9 +5,10 @@ use std::net::SocketAddr;
 use anyhow::{anyhow, Result};
 use futures_util::future::{MapErr, Shared};
 use futures_util::{FutureExt, TryFutureExt};
-use p2panda_blobs::{Blobs as BlobsHandler, MemoryStore as BlobsMemoryStore};
+use p2panda_blobs::Blobs as BlobsHandler;
 use p2panda_core::{Hash, PrivateKey, PublicKey};
 use p2panda_net::{Config as NetworkConfig, NetworkBuilder};
+use rhio_blobs::S3Store;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinError;
 use tokio_util::task::AbortOnDropHandle;
@@ -61,9 +62,9 @@ impl Node {
             .private_key(private_key.clone())
             .sync(sync_protocol);
 
-        // 3. Configure and set up blob store and connection handlers for blob replication.
-        // @TODO: Will be removed soon.
-        let blob_store = BlobsMemoryStore::new();
+        // 3. Configure and set up S3 store and connection handlers for blob replication.
+        // @TODO: What bucket to use here?
+        let blob_store = S3Store::new();
         let (network, blobs_handler) = BlobsHandler::from_builder(builder, blob_store).await?;
         let blobs = Blobs::new(config.s3.clone(), blobs_handler);
 

--- a/rhio/src/node/mod.rs
+++ b/rhio/src/node/mod.rs
@@ -89,7 +89,15 @@ impl Node {
         // 6. Finally spawn actor which orchestrates blob storage and handling, p2panda networking
         //    and NATS JetStream consumers.
         let (node_actor_tx, node_actor_rx) = mpsc::channel(256);
-        let node_actor = NodeActor::new(nats, panda, blobs, watcher, node_actor_rx, watcher_rx);
+        let node_actor = NodeActor::new(
+            private_key,
+            nats,
+            panda,
+            blobs,
+            watcher,
+            node_actor_rx,
+            watcher_rx,
+        );
         let actor_handle = tokio::task::spawn(async move {
             if let Err(err) = node_actor.run().await {
                 error!("node actor failed: {err:?}");

--- a/rhio/src/node/mod.rs
+++ b/rhio/src/node/mod.rs
@@ -55,15 +55,20 @@ impl Node {
             ));
         }
 
-        let sync_protocol =
-            RhioSyncProtocol::new(config.clone(), nats.clone(), private_key.clone());
+        let blob_store = store_from_config(&config).await?;
+
+        let sync_protocol = RhioSyncProtocol::new(
+            config.clone(),
+            nats.clone(),
+            blob_store.clone(),
+            private_key.clone(),
+        );
 
         let builder = NetworkBuilder::from_config(network_config)
             .private_key(private_key.clone())
             .sync(sync_protocol);
 
         // 3. Configure and set up S3 store and connection handlers for blob replication.
-        let blob_store = store_from_config(&config).await?;
         let (network, blobs_handler) =
             BlobsHandler::from_builder(builder, blob_store.clone()).await?;
         let blobs = Blobs::new(config.s3.clone(), blob_store.clone(), blobs_handler);

--- a/rhio/src/node/mod.rs
+++ b/rhio/src/node/mod.rs
@@ -8,13 +8,12 @@ use futures_util::{FutureExt, TryFutureExt};
 use p2panda_blobs::Blobs as BlobsHandler;
 use p2panda_core::{Hash, PrivateKey, PublicKey};
 use p2panda_net::{Config as NetworkConfig, NetworkBuilder};
-use rhio_blobs::S3Store;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinError;
 use tokio_util::task::AbortOnDropHandle;
 use tracing::error;
 
-use crate::blobs::Blobs;
+use crate::blobs::{store_from_config, Blobs};
 use crate::config::Config;
 use crate::nats::Nats;
 use crate::network::sync::RhioSyncProtocol;
@@ -63,8 +62,7 @@ impl Node {
             .sync(sync_protocol);
 
         // 3. Configure and set up S3 store and connection handlers for blob replication.
-        // @TODO: What bucket to use here?
-        let blob_store = S3Store::new();
+        let blob_store = store_from_config(&config).await?;
         let (network, blobs_handler) = BlobsHandler::from_builder(builder, blob_store).await?;
         let blobs = Blobs::new(config.s3.clone(), blobs_handler);
 

--- a/rhio/src/topic.rs
+++ b/rhio/src/topic.rs
@@ -156,8 +156,8 @@ mod tests {
             bucket: ScopedBucket::new("airplanes", public_key_1),
         }
         .into();
-        assert_eq!(subscription_0.id(), subscription_1.id());
-        assert_ne!(subscription_1.id(), subscription_2.id());
+        assert_ne!(subscription_0.id(), subscription_1.id());
+        assert_eq!(subscription_1.id(), subscription_2.id());
 
         // NATS subjects use public key as gossip topic id.
         let subscription_3: Query = Subscription::Subject {

--- a/rhio/src/topic.rs
+++ b/rhio/src/topic.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use p2panda_core::{Hash, PublicKey};
 use p2panda_net::TopicId;
 use p2panda_sync::Topic;
-use rhio_core::{Bucket, ScopedBucket, ScopedSubject};
+use rhio_core::{ScopedBucket, ScopedSubject};
 use serde::{Deserialize, Serialize};
 
 use crate::nats::StreamName;
@@ -45,7 +45,7 @@ impl Subscription {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Publication {
     Bucket {
-        bucket_name: Bucket,
+        bucket: ScopedBucket,
     },
     Subject {
         stream_name: StreamName,
@@ -55,7 +55,7 @@ pub enum Publication {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum Query {
-    Bucket { bucket_name: Bucket },
+    Bucket { bucket: ScopedBucket },
     Subject { subject: ScopedSubject },
     // @TODO(adz): p2panda's API currently does not allow an explicit way to _not_ sync with other
     // peers. We're using this hacky workaround to indicate in the topic that we're not interested
@@ -77,9 +77,7 @@ impl Query {
 impl From<Subscription> for Query {
     fn from(value: Subscription) -> Self {
         match value {
-            Subscription::Bucket { bucket } => Self::Bucket {
-                bucket_name: bucket.bucket_name(),
-            },
+            Subscription::Bucket { bucket } => Self::Bucket { bucket },
             Subscription::Subject { subject, .. } => Self::Subject { subject },
         }
     }
@@ -88,7 +86,7 @@ impl From<Subscription> for Query {
 impl From<Publication> for Query {
     fn from(value: Publication) -> Self {
         match value {
-            Publication::Bucket { bucket_name } => Self::Bucket { bucket_name },
+            Publication::Bucket { bucket } => Self::Bucket { bucket },
             Publication::Subject { subject, .. } => Self::Subject { subject },
         }
     }
@@ -97,8 +95,8 @@ impl From<Publication> for Query {
 impl fmt::Display for Query {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Query::Bucket { bucket_name } => {
-                write!(f, "s3 bucket_name={}", bucket_name)
+            Query::Bucket { bucket } => {
+                write!(f, "s3 bucket={}", bucket)
             }
             Query::Subject { subject } => {
                 write!(f, "nats subject={}", subject)
@@ -112,12 +110,14 @@ impl fmt::Display for Query {
 /// message stream.
 impl Topic for Query {}
 
-/// For gossip ("live-mode") we're subscribing to all S3 data from this _bucket name_ or all NATS
-/// messages from this _author_.
+/// For gossip ("live-mode") we're subscribing to all S3 data or all NATS messages from this
+/// _author_.
 impl TopicId for Query {
     fn id(&self) -> [u8; 32] {
         let hash = match self {
-            Self::Bucket { bucket_name } => Hash::new(format!("{}{}", self.prefix(), bucket_name)),
+            Self::Bucket { bucket } => {
+                Hash::new(format!("{}{}", self.prefix(), bucket.public_key()))
+            }
             Self::Subject { subject, .. } => {
                 Hash::new(format!("{}{}", self.prefix(), subject.public_key()))
             }

--- a/rhio/src/topic.rs
+++ b/rhio/src/topic.rs
@@ -145,15 +145,15 @@ mod tests {
 
         // Buckets use "bucket name" as gossip topic id.
         let subscription_0: Query = Subscription::Bucket {
-            bucket: ScopedBucket::new(public_key_2, "icecreams"),
+            bucket: ScopedBucket::new("icecreams", public_key_2),
         }
         .into();
         let subscription_1: Query = Subscription::Bucket {
-            bucket: ScopedBucket::new(public_key_1, "icecreams"),
+            bucket: ScopedBucket::new("icecreams", public_key_1),
         }
         .into();
         let subscription_2: Query = Subscription::Bucket {
-            bucket: ScopedBucket::new(public_key_1, "airplanes"),
+            bucket: ScopedBucket::new("airplanes", public_key_1),
         }
         .into();
         assert_eq!(subscription_0.id(), subscription_1.id());

--- a/rhio/src/topic.rs
+++ b/rhio/src/topic.rs
@@ -61,6 +61,7 @@ pub enum Query {
     // peers. We're using this hacky workaround to indicate in the topic that we're not interested
     // in syncing. The custom rhio sync implementation will check this before and abort the sync
     // process if this value is set.
+    NoSyncBucket { public_key: PublicKey },
     NoSyncSubject { public_key: PublicKey },
 }
 
@@ -69,6 +70,7 @@ impl Query {
         match self {
             Self::Bucket { .. } => "bucket",
             Self::Subject { .. } => "subject",
+            Self::NoSyncBucket { .. } => "bucket",
             Self::NoSyncSubject { .. } => "subject",
         }
     }
@@ -101,6 +103,7 @@ impl fmt::Display for Query {
             Query::Subject { subject } => {
                 write!(f, "nats subject={}", subject)
             }
+            Query::NoSyncBucket { .. } => write!(f, "no-sync"),
             Query::NoSyncSubject { .. } => write!(f, "no-sync"),
         }
     }
@@ -120,6 +123,9 @@ impl TopicId for Query {
             }
             Self::Subject { subject, .. } => {
                 Hash::new(format!("{}{}", self.prefix(), subject.public_key()))
+            }
+            Self::NoSyncBucket { public_key } => {
+                Hash::new(format!("{}{}", self.prefix(), public_key))
             }
             Self::NoSyncSubject { public_key } => {
                 Hash::new(format!("{}{}", self.prefix(), public_key))


### PR DESCRIPTION
- [x] Ask the blobs store what complete files it currently has and get a list of all their paths, bao hashes and size
    - [x] Use this during sync to exchange with another peer what blobs they're missing
    - [x] Use this to poll this method frequently and check if there's new blobs I can announce via gossip on the network
- [x] Ask the blobs store what incomplete files it currently has
    - [x] Kick off the download process again whenever the rhio process started
- [x] Tell a blobs store that I want it to download a file from a remote peer giving it's hash as an argument
    - Then I can react to blob announcements which interest me, either coming in via sync or gossip
    - This is a two step process:
        - 1) Tell the store about a newly discovered blob using `store.blob_discovered(hash: Hash, path: String, size: u64)`
        - 2) Tell the blob actor to download this blob from the network, it uses `Downloader` from `p2panda-blobs` (the downloader has access to the store) 
- [x] Tell the blob store that a new file was uploaded into S3
    - Then it'll be made ready for syncing eventually and my frequent "polling" logic will kick in to announce it on the network (see above)