### PR TITLE
Fix: error when downloading blobs

### DIFF
--- a/rhio-blobs/src/lib.rs
+++ b/rhio-blobs/src/lib.rs
@@ -2,6 +2,7 @@ mod bao_file;
 mod paths;
 mod s3_file;
 mod store;
+mod utils;
 
 pub use iroh_blobs::Hash as BlobHash;
 

--- a/rhio-blobs/src/utils.rs
+++ b/rhio-blobs/src/utils.rs
@@ -1,0 +1,50 @@
+use iroh_blobs::store::bao_tree::io::sync::WriteAt;
+use iroh_blobs::util::SparseMemFile;
+use s3::Bucket;
+use anyhow::Result;
+
+use crate::bao_file::BaoMeta;
+use crate::Paths;
+
+pub async fn put_meta(bucket: &Bucket, paths: &Paths, meta: &BaoMeta) -> Result<()> {
+    let response = bucket.put_object(paths.meta(), &meta.to_bytes()).await?;
+    if response.status_code() != 200 {
+        return Err(anyhow::anyhow!(
+            "Failed to upload blob meta file to s3 bucket"
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn put_outboard(bucket: &Bucket, paths: &Paths, outboard: &[u8]) -> Result<()> {
+    let response = bucket.put_object(paths.outboard(), outboard).await?;
+    if response.status_code() != 200 {
+        return Err(anyhow::anyhow!(
+            "Failed to upload blob outboard file to s3 bucket"
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn get_meta(bucket: &Bucket, paths: &Paths) -> Result<BaoMeta> {
+    let response = bucket.get_object(paths.meta()).await?;
+    if response.status_code() != 200 {
+        return Err(anyhow::anyhow!("Failed to get blob meta file to s3 bucket"));
+    }
+    let meta = BaoMeta::from_bytes(response.as_slice())?;
+    Ok(meta)
+}
+
+pub async fn get_outboard(bucket: &Bucket, paths: &Paths) -> Result<SparseMemFile> {
+    let response = bucket.get_object(paths.outboard()).await?;
+    if response.status_code() != 200 {
+        return Err(anyhow::anyhow!(
+            "Failed to get blob outboard file to s3 bucket"
+        ));
+    }
+    let mut outboard = SparseMemFile::new();
+    outboard.write_all_at(0, &response.as_slice())?;
+    Ok(outboard)
+}

--- a/rhio-blobs/src/utils.rs
+++ b/rhio-blobs/src/utils.rs
@@ -1,7 +1,7 @@
+use anyhow::Result;
 use iroh_blobs::store::bao_tree::io::sync::WriteAt;
 use iroh_blobs::util::SparseMemFile;
 use s3::Bucket;
-use anyhow::Result;
 
 use crate::bao_file::BaoMeta;
 use crate::Paths;
@@ -45,6 +45,6 @@ pub async fn get_outboard(bucket: &Bucket, paths: &Paths) -> Result<SparseMemFil
         ));
     }
     let mut outboard = SparseMemFile::new();
-    outboard.write_all_at(0, &response.as_slice())?;
+    outboard.write_all_at(0, response.as_slice())?;
     Ok(outboard)
 }

--- a/rhio-blobs/src/utils.rs
+++ b/rhio-blobs/src/utils.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use iroh_blobs::store::bao_tree::io::sync::WriteAt;
 use iroh_blobs::util::SparseMemFile;
 use s3::Bucket;
+use tracing::debug;
 
 use crate::bao_file::BaoMeta;
 use crate::Paths;
@@ -14,6 +15,12 @@ pub async fn put_meta(bucket: &Bucket, paths: &Paths, meta: &BaoMeta) -> Result<
         ));
     }
 
+    debug!(
+        key = %paths.meta(),
+        complete = %meta.complete,
+        "upload complete",
+    );
+
     Ok(())
 }
 
@@ -24,6 +31,12 @@ pub async fn put_outboard(bucket: &Bucket, paths: &Paths, outboard: &[u8]) -> Re
             "Failed to upload blob outboard file to s3 bucket"
         ));
     }
+
+    debug!(
+        key = %paths.outboard(),
+        bytes = %outboard.len(),
+        "upload complete",
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Blob downloads were not completing because of a `LeafHashMismatch` occurring. This was because of two different bugs:
- `S3File` requires `complete()` to be called before the uploaded bytes appear on the bucket (cos it's a multipart upload) and the outboard was getting out-of-date
- We were unnecessarily limiting outboard byte slices received from the bucket

Bonus: while debugging I re-implemented `HttpAdapter` as `S3Reader` which uses the `s3` api under the hood so we don't need to make buckets public anymore.  