### PR TITLE
Improve NATS message handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4102,6 +4102,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "bytes",
  "ciborium",
  "hex",
  "p2panda-core",

--- a/rhio-core/Cargo.toml
+++ b/rhio-core/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.93"
 async-nats = "0.37.0"
+bytes = "1.7.1"
 ciborium = "0.2.2"
 hex = "0.4.3"
 p2panda-core = { git = "https://github.com/p2panda/p2panda.git", rev = "cf78381ba2dbe06f1b6b0ce81d7b34d4b041fffc" }

--- a/rhio-core/src/lib.rs
+++ b/rhio-core/src/lib.rs
@@ -2,6 +2,6 @@ pub mod message;
 pub mod private_key;
 pub mod subject;
 
-pub use message::NetworkMessage;
+pub use message::{hash_nats_message, NetworkMessage};
 pub use private_key::load_private_key_from_file;
 pub use subject::Subject;

--- a/rhio-core/src/message.rs
+++ b/rhio-core/src/message.rs
@@ -85,7 +85,22 @@ pub enum NetworkPayload {
 }
 
 pub fn hash_nats_message(message: &NatsMessage) -> Hash {
-    Hash::new(message.subject.as_bytes())
+    let mut buf = vec![];
+    buf.extend_from_slice(message.subject.as_bytes());
+    buf.extend_from_slice(b"\r\n");
+    if let Some(headers) = &message.headers {
+        for (k, vs) in headers.iter() {
+            for v in vs.iter() {
+                buf.extend_from_slice(k.to_string().as_bytes());
+                buf.extend_from_slice(b": ");
+                buf.extend_from_slice(v.to_string().as_bytes());
+                buf.extend_from_slice(b"\r\n");
+            }
+        }
+        buf.extend_from_slice(b"\r\n");
+    }
+    buf.extend_from_slice(&message.payload);
+    Hash::new(&buf)
 }
 
 #[cfg(test)]

--- a/rhio-core/src/message.rs
+++ b/rhio-core/src/message.rs
@@ -84,6 +84,10 @@ pub enum NetworkPayload {
     NatsMessage(Subject, Bytes, Option<HeaderMap>),
 }
 
+pub fn hash_nats_message(message: &NatsMessage) -> Hash {
+    Hash::new(message.subject.as_bytes())
+}
+
 #[cfg(test)]
 mod tests {
     use p2panda_core::PrivateKey;

--- a/rhio/src/nats/message.rs
+++ b/rhio/src/nats/message.rs
@@ -1,0 +1,6 @@
+use async_nats::Message as NatsMessage;
+use p2panda_core::Hash;
+
+pub fn hash_nats_message(message: &NatsMessage) -> Hash {
+    Hash::new(message.subject.as_bytes())
+}

--- a/rhio/src/nats/message.rs
+++ b/rhio/src/nats/message.rs
@@ -1,6 +1,0 @@
-use async_nats::Message as NatsMessage;
-use p2panda_core::Hash;
-
-pub fn hash_nats_message(message: &NatsMessage) -> Hash {
-    Hash::new(message.subject.as_bytes())
-}

--- a/rhio/src/nats/mod.rs
+++ b/rhio/src/nats/mod.rs
@@ -1,6 +1,5 @@
 mod actor;
 mod consumer;
-pub mod message;
 
 use anyhow::{bail, Context, Result};
 use async_nats::jetstream::consumer::DeliverPolicy;

--- a/rhio/src/nats/mod.rs
+++ b/rhio/src/nats/mod.rs
@@ -1,6 +1,6 @@
 mod actor;
 mod consumer;
-mod message;
+pub mod message;
 
 use anyhow::{bail, Context, Result};
 use async_nats::jetstream::consumer::DeliverPolicy;

--- a/rhio/src/nats/mod.rs
+++ b/rhio/src/nats/mod.rs
@@ -1,5 +1,6 @@
 mod actor;
 mod consumer;
+mod message;
 
 use anyhow::{bail, Context, Result};
 use async_nats::jetstream::consumer::DeliverPolicy;

--- a/rhio/src/network/sync.rs
+++ b/rhio/src/network/sync.rs
@@ -13,13 +13,12 @@ use p2panda_sync::cbor::{into_cbor_sink, into_cbor_stream};
 use p2panda_sync::{FromSync, SyncError, SyncProtocol};
 use rand::random;
 use rhio_blobs::{BlobHash, BucketName, ObjectSize, Paths, S3Store};
-use rhio_core::{NetworkMessage, Subject};
+use rhio_core::{hash_nats_message, NetworkMessage, Subject};
 use serde::{Deserialize, Serialize};
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::{debug, span, Level};
 
 use crate::config::Config;
-use crate::nats::message::hash_nats_message;
 use crate::nats::{ConsumerId, JetStreamEvent, Nats};
 use crate::topic::Query;
 

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -353,7 +353,7 @@ impl NodeActor {
                     None => HeaderMap::new(),
                 };
                 let timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
-                headers.append(NATS_FROM_RHIO_HEADER, timestamp.as_secs().to_string());
+                headers.insert(NATS_FROM_RHIO_HEADER, timestamp.as_secs().to_string());
 
                 self.nats
                     .publish(

--- a/rhio/src/node/actor.rs
+++ b/rhio/src/node/actor.rs
@@ -335,11 +335,11 @@ impl NodeActor {
                         .await?;
                 }
             }
-            NetworkPayload::NatsMessage(message) => {
+            NetworkPayload::NatsMessage(subject, payload, headers) => {
                 // Filter out all incoming messages we're not subscribed to. This can happen
                 // especially when receiving messages over the gossip overlay as they are not
                 // necessarily for us.
-                let subject: Subject = message.subject.clone().try_into()?;
+                let subject: Subject = subject.clone().try_into()?;
                 if !is_subject_matching(&self.subscriptions, &subject, &delivered_from) {
                     return Ok(());
                 }
@@ -348,7 +348,7 @@ impl NodeActor {
                 // "ingested" by rhio. This helps us to identify messages which already have been
                 // processed by us, so we don't need to send them again when they arrive at a NATS
                 // consumer for gossip broadcast.
-                let mut headers = match &message.headers {
+                let mut headers = match &headers {
                     Some(headers) => headers.clone(),
                     None => HeaderMap::new(),
                 };
@@ -356,12 +356,7 @@ impl NodeActor {
                 headers.insert(NATS_FROM_RHIO_HEADER, timestamp.as_secs().to_string());
 
                 self.nats
-                    .publish(
-                        true,
-                        message.subject.to_string(),
-                        Some(headers),
-                        message.payload.to_vec(),
-                    )
+                    .publish(true, subject.to_string(), Some(headers), payload.to_vec())
                     .await?;
             }
         }


### PR DESCRIPTION
* Make sure to only insert header once
* Generate NATS message hash over subject, payload and headers
* Only send subject, payload and headers over the wire