### PR TITLE
Add HTTP health endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower 0.5.1",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,7 +1908,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -2565,6 +2620,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "maybe-async"
@@ -4064,6 +4125,7 @@ dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
+ "axum",
  "ciborium",
  "clap",
  "directories",
@@ -4527,6 +4589,16 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -5303,6 +5375,22 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/rhio/Cargo.toml
+++ b/rhio/Cargo.toml
@@ -14,6 +14,7 @@ name = "rhio"
 anyhow = "1.0.93"
 async-nats = "0.37.0"
 async-trait = "0.1.83"
+axum = "0.7.9"
 ciborium = "0.2.2"
 clap = { version = "4.5.8", features = ["derive"] }
 directories = "5.0.1"

--- a/rhio/src/config.rs
+++ b/rhio/src/config.rs
@@ -26,6 +26,9 @@ const DEFAULT_BIND_PORT: u16 = 9102;
 /// Default rhio network id.
 const DEFAULT_NETWORK_ID: &str = "rhio-default-network-1";
 
+/// Default rhio HTTP port.
+pub const DEFAULT_HTTP_BIND_PORT: u16 = 3000;
+
 /// Default HTTP API endpoint for MinIO server.
 pub const S3_ENDPOINT: &str = "http://localhost:9000";
 
@@ -67,6 +70,11 @@ struct Cli {
     #[arg(short = 'p', long, value_name = "PORT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     bind_port: Option<u16>,
+
+    /// HTTP bind port of rhio node.
+    #[arg(short = 'b', long, value_name = "PORT")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    http_bind_port: Option<u16>,
 
     /// Path to file containing hexadecimal-encoded Ed25519 private key.
     #[arg(short = 'k', long, value_name = "PATH")]
@@ -182,6 +190,7 @@ pub struct NatsCredentials {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NodeConfig {
     pub bind_port: u16,
+    pub http_bind_port: u16,
     #[serde(rename = "nodes")]
     pub known_nodes: Vec<KnownNode>,
     pub private_key_path: PathBuf,
@@ -192,6 +201,7 @@ impl Default for NodeConfig {
     fn default() -> Self {
         Self {
             bind_port: DEFAULT_BIND_PORT,
+            http_bind_port: DEFAULT_HTTP_BIND_PORT,
             known_nodes: vec![],
             private_key_path: DEFAULT_PRIVATE_KEY_PATH.into(),
             network_id: DEFAULT_NETWORK_ID.to_string(),
@@ -264,6 +274,7 @@ mod tests {
                 "config.yaml",
                 r#"
 bind_port: 1112
+http_bind_port: 2223
 private_key_path: "/usr/app/rhio/private.key"
 network_id: "rhio-default-network-1"
 
@@ -342,6 +353,7 @@ subscribe:
                     },
                     node: NodeConfig {
                         bind_port: 1112,
+                        http_bind_port: 2223,
                         known_nodes: vec![KnownNode {
                             public_key:
                                 "6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a"

--- a/rhio/src/http_server.rs
+++ b/rhio/src/http_server.rs
@@ -1,0 +1,28 @@
+use axum::{
+    http::{Response, StatusCode},
+    response::{Html, IntoResponse},
+    routing::get,
+    Router,
+};
+use tracing::debug;
+
+use crate::config::DEFAULT_HTTP_BIND_PORT;
+
+pub async fn run(bind_port: u16) -> anyhow::Result<()> {
+    // build our application with a route
+    let app = Router::new().route("/health", get(handler_200));
+
+    // run it
+    let listener =
+        tokio::net::TcpListener::bind(format!("localhost:{bind_port}")).await?;
+    debug!(
+        "HTTP health endpoint listening on {}",
+        listener.local_addr()?
+    );
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn handler_200() -> impl IntoResponse {
+    (StatusCode::OK, "rhio service active")
+}

--- a/rhio/src/http_server.rs
+++ b/rhio/src/http_server.rs
@@ -13,8 +13,7 @@ pub async fn run(bind_port: u16) -> anyhow::Result<()> {
     let app = Router::new().route("/health", get(handler_200));
 
     // run it
-    let listener =
-        tokio::net::TcpListener::bind(format!("localhost:{bind_port}")).await?;
+    let listener = tokio::net::TcpListener::bind(format!("localhost:{bind_port}")).await?;
     debug!(
         "HTTP health endpoint listening on {}",
         listener.local_addr()?

--- a/rhio/src/lib.rs
+++ b/rhio/src/lib.rs
@@ -1,4 +1,5 @@
 #[allow(dead_code, unused, unused_imports)]
+pub mod http_server;
 mod blobs;
 pub mod config;
 mod nats;

--- a/rhio/src/lib.rs
+++ b/rhio/src/lib.rs
@@ -1,7 +1,7 @@
-#[allow(dead_code, unused, unused_imports)]
-pub mod http_server;
 mod blobs;
 pub mod config;
+#[allow(dead_code, unused, unused_imports)]
+pub mod http_server;
 mod nats;
 mod network;
 mod node;

--- a/rhio/src/main.rs
+++ b/rhio/src/main.rs
@@ -143,7 +143,7 @@ async fn main() -> Result<()> {
 
     if let Err(err) = tokio::spawn(http_server::run(config.node.http_bind_port)).await? {
         error!("failed to start http server: {err}");
-        return Ok(())
+        return Ok(());
     };
     tokio::signal::ctrl_c().await?;
 

--- a/rhio/src/main.rs
+++ b/rhio/src/main.rs
@@ -5,11 +5,11 @@ use p2panda_core::PublicKey;
 use rhio::config::{load_config, LocalNatsSubject, RemoteNatsSubject, RemoteS3Bucket};
 use rhio::tracing::setup_tracing;
 use rhio::{
-    FilesSubscription, FilteredMessageStream, MessagesSubscription, Node, Publication, StreamName,
-    Subscription,
+    http_server, FilesSubscription, FilteredMessageStream, MessagesSubscription, Node, Publication,
+    StreamName, Subscription,
 };
 use rhio_core::{load_private_key_from_file, Subject};
-use tracing::info;
+use tracing::{error, info};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -39,6 +39,8 @@ async fn main() -> Result<()> {
     for address in addresses {
         info!("  - {}", address);
     }
+    info!("‣ health endpoint:");
+    info!("  - localhost:{}", config.node.http_bind_port);
 
     if let Some(publish) = config.publish {
         for bucket_name in publish.s3_buckets {
@@ -139,6 +141,10 @@ async fn main() -> Result<()> {
         }
     };
 
+    if let Err(err) = tokio::spawn(http_server::run(config.node.http_bind_port)).await? {
+        error!("failed to start http server: {err}");
+        return Ok(())
+    };
     tokio::signal::ctrl_c().await?;
 
     info!("");


### PR DESCRIPTION
Basic HTTP endpoint for satisfying Kubernetes health check requirements. If the `rhio` service is running an `OK 200` response will be returned when a `GET` request is made to `/health`.