### PR TITLE
Resolve FQDN endpoints from config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -68,7 +68,7 @@
 # ﾟ･｡+☆
 
 # List of known node addresses we want to connect to directly. Addresses have
-# to be IP addresses and must include a port number.
+# to be FQDN's (absolute domain names) or IP addresses with a port number.
 #
 # NOTE: Make sure that nodes mentioned in this list are directly reachable
 # (they need to be hosted with a static IP address).
@@ -76,6 +76,7 @@
 # nodes:
 #   - public_key: "<public-key>"
 #     endpoints:
+#       - "staging.rhio.org"
 #       - "192.168.178.100:9102"
 #       - "[2a02:8109:9c9a:4200:eb13:7c0a:4201:8128]:9103"
 

--- a/rhio/src/config.rs
+++ b/rhio/src/config.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
@@ -213,7 +212,7 @@ impl Default for NodeConfig {
 pub struct KnownNode {
     pub public_key: PublicKey,
     #[serde(rename = "endpoints")]
-    pub direct_addresses: Vec<SocketAddr>,
+    pub direct_addresses: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
@@ -296,6 +295,7 @@ nats:
 nodes:
     - public_key: "6ee91c497d577b5c21ab53212c194b56779addd8088d8b850ece447c8844fe8a"
       endpoints:
+        - "some.hostname.org."
         - "192.168.178.100:1112"
         - "[2a02:8109:9c9a:4200:eb13:7c0a:4201:8128]:1113"
 
@@ -364,6 +364,7 @@ subscribe:
                                     .parse()
                                     .unwrap(),
                             direct_addresses: vec![
+                                "some.hostname.org.".into(),
                                 "192.168.178.100:1112".parse().unwrap(),
                                 "[2a02:8109:9c9a:4200:eb13:7c0a:4201:8128]:1113"
                                     .parse()

--- a/rhio/src/node/mod.rs
+++ b/rhio/src/node/mod.rs
@@ -49,7 +49,7 @@ impl Node {
         };
 
         for node in &config.node.known_nodes {
-            // Resolve FQND strings into IP addresses.
+            // Resolve FQDN strings into IP addresses.
             let mut direct_addresses = Vec::new();
             for addr in &node.direct_addresses {
                 for resolved in tokio::net::lookup_host(addr).await? {

--- a/rhio/src/node/mod.rs
+++ b/rhio/src/node/mod.rs
@@ -49,11 +49,16 @@ impl Node {
         };
 
         for node in &config.node.known_nodes {
-            network_config.direct_node_addresses.push((
-                node.public_key,
-                node.direct_addresses.clone(),
-                None,
-            ));
+            // Resolve FQND strings into IP addresses.
+            let mut direct_addresses = Vec::new();
+            for addr in &node.direct_addresses {
+                for resolved in tokio::net::lookup_host(addr).await? {
+                    direct_addresses.push(resolved);
+                }
+            }
+            network_config
+                .direct_node_addresses
+                .push((node.public_key, direct_addresses, None));
         }
 
         let blob_store = store_from_config(&config).await?;


### PR DESCRIPTION
Allow FQDN (absolute domain names) in `nodes` config:

```yaml
nodes:
  - public_key: "<public-key>"
    endpoints:
      - "staging.rhio.org"
      - "192.168.178.100:9102"
      - "[2a02:8109:9c9a:4200:eb13:7c0a:4201:8128]:9103"
```