### PR TITLE
Integration tests s3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,7 +302,7 @@ dependencies = [
  "attohttpc 0.28.0",
  "home",
  "log",
- "quick-xml",
+ "quick-xml 0.32.0",
  "rust-ini",
  "serde",
  "thiserror 1.0.63",
@@ -448,6 +457,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +565,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -775,6 +803,24 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-epoch"
@@ -1704,6 +1750,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7685beb53fc20efc2605f32f5d51e9ba18b8ef237961d1760169d2290d3bee"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -2717,6 +2773,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nugine-rust-utils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dcd9cfa92246a9c7ca0671e00733c4e9d77ee1fa0ae08c9a181b7c8802aea2"
+dependencies = [
+ "simdutf8",
+]
+
+[[package]]
 name = "nuid"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,6 +3170,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "numeric_cast"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6699ec124a5322dd30184abe24b2b9a92237ed0fe8e038f1f410bf7cccfe8b33"
 
 [[package]]
 name = "object"
@@ -3201,6 +3282,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "overload"
@@ -3393,6 +3480,24 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "pear"
@@ -3841,6 +3946,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4270,6 +4385,8 @@ dependencies = [
  "rhio-blobs",
  "rhio-core",
  "rust-s3",
+ "s3-server",
+ "s3s",
  "serde",
  "serde_json",
  "tokio",
@@ -4277,6 +4394,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -4403,7 +4521,7 @@ dependencies = [
  "minidom",
  "native-tls",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.32.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4569,6 +4687,97 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "s3-server"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "hyper-util",
+ "s3s",
+ "s3s-fs",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "s3s"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa54e3b4b4791c8c62291516997866b4f265c3fcbfdbcdd0b8da62896fba8bfa"
+dependencies = [
+ "arrayvec",
+ "async-trait",
+ "atoi",
+ "base64-simd",
+ "bytes",
+ "bytestring",
+ "chrono",
+ "crc32c",
+ "crc32fast",
+ "digest",
+ "futures",
+ "hex-simd",
+ "hmac",
+ "http-body 1.0.1",
+ "http-body-util",
+ "httparse",
+ "hyper 1.5.2",
+ "itoa",
+ "memchr",
+ "mime",
+ "nom",
+ "nugine-rust-utils",
+ "numeric_cast",
+ "pin-project-lite",
+ "quick-xml 0.36.2",
+ "serde",
+ "serde_urlencoded",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sync_wrapper 1.0.1",
+ "thiserror 1.0.63",
+ "time",
+ "tokio",
+ "tracing",
+ "transform-stream",
+ "urlencoding",
+ "zeroize",
+]
+
+[[package]]
+name = "s3s-fs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b045f5ab67e8536d147ae48e038f6f533717fe5ddb0a68d0ba8f922ce7fb293f"
+dependencies = [
+ "async-trait",
+ "base64-simd",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "hex-simd",
+ "md-5",
+ "mime",
+ "nugine-rust-utils",
+ "numeric_cast",
+ "path-absolutize",
+ "s3s",
+ "serde_json",
+ "thiserror 1.0.63",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-error",
+ "transform-stream",
+ "uuid",
+]
 
 [[package]]
 name = "salsa20"
@@ -4861,6 +5070,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-dns"
@@ -5561,6 +5776,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5608,6 +5833,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "transform-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05034de7a8fcb11796a36478a2a8b16dca6772644dec5f49f709d5c66a38d359"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -5768,6 +6002,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5792,6 +6032,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5808,6 +6057,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "rhio",
   "rhio-blobs",
   "rhio-core",
+  "s3-server",
 ]
 
 [workspace.lints.rust]
@@ -24,6 +25,7 @@ p2panda-net = { git = "https://github.com/p2panda/p2panda.git", rev = "26474c721
 p2panda-sync = { git = "https://github.com/p2panda/p2panda.git", rev = "26474c72151d304fc86aca147799b5dd7cd640d5", features = ["cbor"], default-features = false }
 rhio-blobs = { path = "rhio-blobs" }
 rhio-core = { path = "rhio-core" }
+s3-server = { path = "s3-server" }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.132"
 futures-lite = "2.5.0"
@@ -48,4 +50,11 @@ once_cell = "1.20.2"
 dashmap = "6.1.0"
 futures = { version = "0.3.28", default-features = false, features = ["std"] }
 pin-project = "1.1.8"
-
+s3s-fs = { version = "0.10.0" }
+s3s = { version = "0.10.0" }
+hyper-util = { version = "0.1.10", features = [
+    "server",
+    "http1",
+    "http2",
+    "tokio",
+] }

--- a/rhio/Cargo.toml
+++ b/rhio/Cargo.toml
@@ -51,3 +51,6 @@ figment = { workspace = true, features = ["test"] }
 once_cell.workspace = true
 dashmap.workspace = true
 serde_json.workspace = true
+s3-server.workspace = true
+s3s.workspace = true
+url.workspace = true

--- a/rhio/src/context_builder.rs
+++ b/rhio/src/context_builder.rs
@@ -140,8 +140,17 @@ impl ContextBuilder {
             private_key.clone(),
         );
 
-        let sync_config =
-            SyncConfiguration::new(sync_protocol).resync(ResyncConfiguration::default());
+        let resync_config = config
+            .node
+            .protocol
+            .map(|c| {
+                ResyncConfiguration::new()
+                    .poll_interval(c.poll_interval_seconds)
+                    .interval(c.resync_interval_seconds)
+            })
+            .unwrap_or_default();
+
+        let sync_config = SyncConfiguration::new(sync_protocol).resync(resync_config);
 
         let builder = NetworkBuilder::from_config(p2p_network_config)
             .private_key(private_key.clone())

--- a/rhio/src/tests/blob_replication.rs
+++ b/rhio/src/tests/blob_replication.rs
@@ -1,0 +1,56 @@
+use crate::{
+    tests::configuration::{create_two_node_blob_setup, TwoClusterBlobSetup},
+    tracing::setup_tracing,
+};
+use anyhow::{bail, Context, Result};
+use rand::Rng;
+use std::time::{Duration, Instant};
+use tracing::info;
+
+#[test]
+pub fn test_e2e_blob_replication() -> Result<()> {
+    setup_tracing(Some("=INFO".into()));
+
+    let TwoClusterBlobSetup {
+        rhio_source,
+        rhio_target,
+        s3_source,
+        s3_target,
+    } = create_two_node_blob_setup()?;
+    info!("environment started");
+
+    let mut rng = rand::thread_rng();
+    let source_bytes: Vec<u8> = (0..128).map(|_| rng.gen()).collect();
+
+    s3_source.put_bytes("source-bucket", "test.txt", &source_bytes)?;
+
+    wait_for_condition(Duration::from_secs(10), || {
+        s3_target
+            .exists("target-bucket", "test.txt")
+            .context("Waiting for file")
+    })?;
+
+    let target_bytes = s3_target.get_bytes("target-bucket", "test.txt")?;
+
+    assert_eq!(source_bytes, target_bytes);
+
+    rhio_source.discard()?;
+    rhio_target.discard()?;
+    s3_source.discard();
+    s3_target.discard();
+    Ok(())
+}
+
+fn wait_for_condition<F>(timeout: Duration, condition: F) -> Result<()>
+where
+    F: Fn() -> Result<bool>,
+{
+    let start = Instant::now();
+    while Instant::now().duration_since(start) < timeout {
+        if condition()? {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+    bail!("timeout waiting condition")
+}

--- a/rhio/src/tests/configuration.rs
+++ b/rhio/src/tests/configuration.rs
@@ -1,7 +1,20 @@
+use crate::{
+    config::{
+        Config, LocalNatsSubject, NatsConfig, ProtocolConfig, PublishConfig, RemoteNatsSubject,
+        RemoteS3Bucket, S3Config, SubscribeConfig,
+    },
+    nats::client::fake::{
+        blocking::BlockingClient,
+        client::{FakeNatsClient, FakeNatsMessages},
+    },
+};
+use anyhow::anyhow;
 use anyhow::Context;
 use once_cell::sync::Lazy;
 use p2panda_core::{PrivateKey, PublicKey};
 use rhio_core::Subject;
+use s3_server::FakeS3Server;
+use s3s::auth::SimpleAuth;
 use std::{
     path::PathBuf,
     str::FromStr,
@@ -10,19 +23,9 @@ use std::{
         Arc,
     },
 };
-use tokio::runtime::Builder;
-use tracing::info;
-
-use crate::{
-    config::{
-        Config, LocalNatsSubject, NatsConfig, PublishConfig, RemoteNatsSubject, S3Config,
-        SubscribeConfig,
-    },
-    nats::client::fake::{
-        blocking::BlockingClient,
-        client::{FakeNatsClient, FakeNatsMessages},
-    },
-};
+use tokio::runtime::{Builder, Runtime};
+use tracing::{debug, info};
+use url::Url;
 
 use super::fake_rhio_server::FakeRhioServer;
 use anyhow::Result;
@@ -30,6 +33,7 @@ use anyhow::Result;
 static TEST_INSTANCE_HTTP_PORT: Lazy<AtomicU16> = Lazy::new(|| AtomicU16::new(8080));
 static TEST_INSTANCE_RHIO_PORT: Lazy<AtomicU16> = Lazy::new(|| AtomicU16::new(31000));
 static TEST_INSTANCE_NATS_PORT: Lazy<AtomicU16> = Lazy::new(|| AtomicU16::new(4222));
+static TEST_INSTANCE_S3_PORT: Lazy<AtomicU16> = Lazy::new(|| AtomicU16::new(33000));
 
 /// A structure representing the setup for a two-cluster messaging system.
 ///
@@ -130,6 +134,141 @@ pub fn create_two_node_messaging_setup() -> Result<TwoClusterMessagingSetup> {
     Ok(setup)
 }
 
+/// A structure representing the setup for a two-cluster blob storage system.
+///
+/// This setup includes two instances of `FakeRhioServer` and two instances of
+/// `FakeS3Server`. The `FakeRhioServer` instances are configured to communicate
+/// with each other and the `FakeS3Server` instances are configured to handle
+/// blob storage and retrieval.
+///
+pub struct TwoClusterBlobSetup {
+    pub(crate) rhio_source: FakeRhioServer,
+    pub(crate) rhio_target: FakeRhioServer,
+    pub(crate) s3_source: FakeS3Server,
+    pub(crate) s3_target: FakeS3Server,
+}
+
+/// Creates a two-node blob storage setup for testing purposes.
+///
+/// This function sets up two instances of `FakeRhioServer` and two instances of
+/// `FakeS3Server`. It configures the necessary network and blob subscription settings
+/// for the nodes to communicate with each other and handle blob storage and retrieval.
+///
+/// # Returns
+///
+/// A `Result` containing a `TwoClusterBlobSetup` structure if the setup is successful,
+/// or an `anyhow::Error` if an error occurs during the setup.
+///
+/// # Example
+///
+/// ```rust
+/// let setup = create_two_node_blob_setup().expect("Failed to create two-node blob setup");
+/// ```
+///
+/// # Errors
+///
+/// This function will return an error if there is an issue creating the S3 servers
+/// or starting the `FakeRhioServer` instances.
+pub fn create_two_node_blob_setup() -> Result<TwoClusterBlobSetup> {
+    let nats_source_config = generate_nats_config();
+    let nats_target_config = generate_nats_config();
+    info!("nats source config {:?}", nats_source_config);
+    info!("nats target config {:?}", nats_target_config);
+
+    let s3_source_config = generate_s3_config();
+    let s3_target_config = generate_s3_config();
+    info!("s3 source config {:?}", s3_source_config);
+    info!("s3 target config {:?}", s3_target_config);
+
+    let mut rhio_source_config =
+        generate_rhio_config(&nats_source_config, &Some(s3_source_config.clone()));
+    let rhio_source_private_key = PrivateKey::new();
+
+    let mut rhio_target_config =
+        generate_rhio_config(&nats_target_config, &Some(s3_target_config.clone()));
+    let rhio_target_private_key = PrivateKey::new();
+
+    configure_network(vec![
+        (&mut rhio_source_config, &rhio_source_private_key),
+        (&mut rhio_target_config, &rhio_target_private_key),
+    ]);
+
+    info!("rhio source config {:?} ", rhio_source_config.node);
+    info!("rhio target config {:?} ", rhio_target_config.node);
+
+    configure_blob_subscription(
+        &mut rhio_source_config,
+        &rhio_source_private_key.public_key(),
+        &mut rhio_target_config,
+        &"source-bucket",
+        &"target-bucket",
+    );
+
+    let test_runtime = Arc::new(
+        Builder::new_multi_thread()
+            .enable_io()
+            .enable_time()
+            .thread_name("test-runtime")
+            .worker_threads(5)
+            .build()
+            .expect("test tokio runtime"),
+    );
+
+    let s3_source = new_s3_server(&s3_source_config, test_runtime.clone())?;
+    s3_source.create_bucket("source-bucket")?;
+
+    let s3_target = new_s3_server(&s3_target_config, test_runtime.clone())?;
+    s3_target.create_bucket("target-bucket")?;
+
+    let rhio_source =
+        FakeRhioServer::try_start(rhio_source_config.clone(), rhio_source_private_key.clone())
+            .context("Source RhioServer")?;
+    let rhio_target =
+        FakeRhioServer::try_start(rhio_target_config.clone(), rhio_target_private_key.clone())
+            .context("Target RhioServer")?;
+
+    let setup = TwoClusterBlobSetup {
+        rhio_source,
+        rhio_target,
+        s3_source,
+        s3_target,
+    };
+
+    Ok(setup)
+}
+
+fn new_s3_server(s3_config: &S3Config, runtime: Arc<Runtime>) -> Result<FakeS3Server> {
+    let maybe_auth = if let Some(credentials) = &s3_config.credentials {
+        match (&credentials.access_key, &credentials.secret_key) {
+            (Some(access_key), Some(secret_key)) => {
+                Some(SimpleAuth::from_single(access_key, secret_key.as_str()))
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    debug!("s3 server {} has auth {:?}", s3_config.endpoint, maybe_auth);
+
+    let url: Url = s3_config
+        .endpoint
+        .parse()
+        .context(format!("Invalid endpoint address {}", s3_config.endpoint))?;
+
+    let host = url
+        .host()
+        .ok_or(anyhow!("s3 url does not have host"))?
+        .to_string();
+    let port = url
+        .port()
+        .ok_or(anyhow!("s3 url does not have port specified"))?;
+
+    let s3 = FakeS3Server::new(host, port, maybe_auth, runtime.clone())
+        .context(format!("Creating FakeS3Server {}", s3_config.endpoint))?;
+    Ok(s3)
+}
+
 pub fn generate_rhio_config(nats_config: &NatsConfig, s3_config: &Option<S3Config>) -> Config {
     let http_port = TEST_INSTANCE_HTTP_PORT.fetch_add(1, Ordering::SeqCst);
     let rhio_port = TEST_INSTANCE_RHIO_PORT.fetch_add(1, Ordering::SeqCst);
@@ -142,6 +281,10 @@ pub fn generate_rhio_config(nats_config: &NatsConfig, s3_config: &Option<S3Confi
     config.node.known_nodes = vec![];
     config.node.private_key_path = PathBuf::from("/tmp/rhio_private_key");
     config.node.network_id = "test".to_string();
+    config.node.protocol = Some(ProtocolConfig {
+        poll_interval_seconds: 1,
+        resync_interval_seconds: 5,
+    });
     config.log_level = Some("=INFO".to_string());
     config
 }
@@ -151,6 +294,21 @@ pub fn generate_nats_config() -> NatsConfig {
     NatsConfig {
         endpoint: format!("nats://localhost:{}", nats_port),
         credentials: None,
+    }
+}
+
+pub fn generate_s3_config() -> S3Config {
+    let port = TEST_INSTANCE_S3_PORT.fetch_add(1, Ordering::SeqCst);
+    S3Config {
+        endpoint: format!("http://127.0.0.1:{}", port),
+        region: "127.0.0.1".to_string(),
+        credentials: Some(s3::creds::Credentials {
+            access_key: Some("minio".into()),
+            secret_key: Some("minio123".into()),
+            security_token: None,
+            session_token: None,
+            expiration: None,
+        }),
     }
 }
 
@@ -232,6 +390,69 @@ pub fn configure_message_subscription(
             public_key: publisher_pub_key.clone(),
             subject: Subject::from_str(subject).unwrap(),
             stream_name: stream.into(),
+        });
+    }
+}
+/// Configures blob subscription between a publisher and a subscriber.
+///
+/// This function sets up the necessary configurations for a publisher to publish blobs
+/// to a specific S3 bucket, and for a subscriber to subscribe to those blobs.
+///
+/// # Arguments
+///
+/// * `publisher` - A mutable reference to the configuration of the publisher node.
+/// * `publisher_pub_key` - The public key of the publisher node.
+/// * `subscriber` - A mutable reference to the configuration of the subscriber node.
+/// * `publisher_bucket` - The name of the S3 bucket to which blobs will be published.
+/// * `subscriber_bucket` - The name of the S3 bucket to which blobs will be subscribed.
+///
+/// # Example
+///
+/// ```rust
+/// let mut publisher_config = Config::default();
+/// let publisher_private_key = PrivateKey::new();
+/// let mut subscriber_config = Config::default();
+///
+/// configure_blob_subscription(
+///     &mut publisher_config,
+///     &publisher_private_key.public_key(),
+///     &mut subscriber_config,
+///     "source-bucket",
+///     "target-bucket",
+/// );
+/// ```
+///
+/// # Errors
+///
+/// This function will return an error if there is an issue configuring the blob subscription.
+pub fn configure_blob_subscription(
+    publisher: &mut Config,
+    publisher_pub_key: &PublicKey,
+    subscriber: &mut Config,
+    publisher_bucket: &str,
+    subscriber_bucket: &str,
+) {
+    if publisher.publish.is_none() {
+        publisher.publish = Some(PublishConfig {
+            s3_buckets: vec![],
+            nats_subjects: vec![],
+        });
+    }
+    if subscriber.subscribe.is_none() {
+        subscriber.subscribe = Some(SubscribeConfig {
+            s3_buckets: vec![],
+            nats_subjects: vec![],
+        });
+    }
+    if let Some(publish_config) = &mut publisher.publish {
+        publish_config.s3_buckets.push(publisher_bucket.into());
+    }
+
+    if let Some(subscriber_config) = &mut subscriber.subscribe {
+        subscriber_config.s3_buckets.push(RemoteS3Bucket {
+            remote_bucket_name: publisher_bucket.into(),
+            local_bucket_name: subscriber_bucket.into(),
+            public_key: publisher_pub_key.clone(),
         });
     }
 }

--- a/rhio/src/tests/mod.rs
+++ b/rhio/src/tests/mod.rs
@@ -1,3 +1,4 @@
+pub mod blob_replication;
 pub mod configuration;
 pub mod fake_rhio_server;
 pub mod message_replication;

--- a/s3-server/Cargo.toml
+++ b/s3-server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "s3-server"
+description = "Simple S3 server for testing purposes"
+version = "0.1.1"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[lib]
+name = "s3_server"
+
+[dependencies]
+anyhow.workspace = true
+s3s-fs.workspace = true
+s3s.workspace = true
+hyper-util.workspace = true
+url.workspace = true
+tempfile.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tokio-util.workspace = true

--- a/s3-server/src/lib.rs
+++ b/s3-server/src/lib.rs
@@ -1,0 +1,266 @@
+use std::fs::File;
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context, Result};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto::Builder as ConnBuilder;
+use s3s::auth::SimpleAuth;
+use s3s::service::{S3ServiceBuilder, SharedS3Service};
+use s3s_fs::FileSystem;
+use std::io::Read;
+use std::io::Write;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::runtime::Runtime;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error};
+
+/// `FakeS3Server` is a fake implementation of an S3 server for testing purposes.
+/// It provides methods to create buckets, check for file existence, read and write files,
+/// and manage the server lifecycle.
+///
+/// # Fields
+/// - `runtime`: An `Arc` to a Tokio runtime used to run the server.
+/// - `handle`: A `JoinHandle` to the async task running the server.
+/// - `cancel`: A `CancellationToken` to signal the server to stop.
+/// - `root`: A temporary directory used as the root filesystem for the server.
+///
+/// # Methods
+/// - `new`: Creates a new instance of `FakeS3Server`.
+/// - `run_inner`: Internal method to run the server, accepting connections and serving requests.
+/// - `create_bucket`: Creates a new bucket in the server's filesystem.
+/// - `exists`: Checks if a file exists in a specified bucket.
+/// - `get_bytes`: Reads the contents of a file in a specified bucket as bytes.
+/// - `get`: Opens a file in a specified bucket.
+/// - `put_bytes`: Writes bytes to a file in a specified bucket.
+/// - `discard`: Stops the server and cleans up resources.
+///
+pub struct FakeS3Server {
+    #[allow(dead_code)]
+    runtime: Arc<Runtime>,
+    handle: JoinHandle<Result<()>>,
+    cancel: CancellationToken,
+    root: TempDir,
+}
+
+impl FakeS3Server {
+    /// Creates a new instance of `FakeS3Server`.
+    ///
+    /// # Arguments
+    ///
+    /// * `host` - The host address for the server.
+    /// * `port` - The port number for the server.
+    /// * `maybe_auth` - Optional authentication for the server.
+    /// * `runtime` - The runtime for the server.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the new `FakeS3Server` instance or an error.
+    pub fn new(
+        host: String,
+        port: u16,
+        maybe_auth: Option<SimpleAuth>,
+        runtime: Arc<Runtime>,
+    ) -> Result<FakeS3Server> {
+        // Fake S3 server root filesystem
+        let root = TempDir::new().context("Temporary directory")?;
+        debug!(
+            "FakeS3Server {}:{} has root fs {:?}",
+            host,
+            port,
+            root.path()
+        );
+
+        // Setup S3 File system
+        let fs = FileSystem::new(&root)
+            .map_err(|err| anyhow!("{:?}", err))
+            .context("FileSysten creation")?;
+
+        // Setup S3 service
+        let service = {
+            let mut builder = S3ServiceBuilder::new(fs);
+            if let Some(auth) = maybe_auth {
+                builder.set_auth(auth);
+            }
+            builder.build()
+        };
+        // Running HTTP server
+        let cancel = CancellationToken::new();
+        let cancel_token = cancel.clone();
+        let handle = runtime.spawn(async move {
+            FakeS3Server::run_inner(service.into_shared(), cancel_token, host, port)
+                .await
+                .inspect_err(|e| error!("Fake3Server: connection loop failure {}", e))
+        });
+        Ok(FakeS3Server {
+            runtime,
+            handle,
+            root,
+            cancel,
+        })
+    }
+
+    /// Runs the inner server logic.
+    ///
+    /// # Arguments
+    ///
+    /// * `service` - The shared S3 service.
+    /// * `cancel_token` - The cancellation token for the server.
+    /// * `host` - The host address for the server.
+    /// * `port` - The port number for the server.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating success or failure.
+    async fn run_inner(
+        service: SharedS3Service,
+        cancel_token: CancellationToken,
+        host: String,
+        port: u16,
+    ) -> Result<()> {
+        let connection = ConnBuilder::new(TokioExecutor::new());
+
+        let listener = TcpListener::bind((host, port))
+            .await
+            .context("FakeS3Server: tcp listener binding")?;
+
+        let result = tokio::select! {
+            result = listener.accept() => {
+                let (socket, _) = match result {
+                    Ok(ok) => ok,
+                    Err(err) => {
+                        bail!("FakeS3Server: error accepting connection: {err}");
+                    }
+                };
+                let service = service.clone();
+                let conn = connection.clone();
+                tokio::spawn(async move {
+                    conn.serve_connection(TokioIo::new(socket), service).await
+                        .inspect_err(|e| error!("Serve connection error: {}", e))
+                        .ok();
+                });
+            }
+            _ = cancel_token.cancelled() => bail!("FakeS3Server: cancelled")
+        };
+        Ok(result)
+    }
+
+    /// Creates a new bucket in the fake S3 server.
+    ///
+    /// # Arguments
+    ///
+    /// * `bucket` - The name of the bucket to create.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating success or failure.
+    pub fn create_bucket<P: AsRef<str>>(&self, bucket: P) -> Result<()> {
+        let path = self.root.path().join(bucket.as_ref());
+        debug!(
+            "FakeS3Server: creating bucket {}, fs path {}",
+            bucket.as_ref(),
+            path.to_str().unwrap()
+        );
+        std::fs::create_dir(path).context("Create bucket path")?;
+        Ok(())
+    }
+
+    /// Checks if a file exists in the specified bucket.
+    ///
+    /// # Arguments
+    ///
+    /// * `bucket` - The name of the bucket.
+    /// * `file_path` - The path of the file to check.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a boolean indicating whether the file exists.
+    pub fn exists<P: AsRef<str>>(&self, bucket: P, file_path: P) -> Result<bool> {
+        let path = self
+            .root
+            .path()
+            .join(bucket.as_ref())
+            .join(file_path.as_ref());
+        Ok(std::fs::exists(path.as_path())?)
+    }
+
+    /// Retrieves the contents of a file as bytes from the specified bucket.
+    ///
+    /// # Arguments
+    ///
+    /// * `bucket` - The name of the bucket.
+    /// * `file_path` - The path of the file to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a vector of bytes representing the file contents.
+    pub fn get_bytes<P: AsRef<str>>(&self, bucket: P, file_path: P) -> Result<Vec<u8>> {
+        let mut file = self.get(bucket, file_path)?;
+        let mut target_bytes = Vec::new();
+        file.read_to_end(&mut target_bytes)
+            .context("File reading")?;
+        Ok(target_bytes)
+    }
+
+    /// Retrieves a file from the specified bucket.
+    ///
+    /// # Arguments
+    ///
+    /// * `bucket` - The name of the bucket.
+    /// * `file_path` - The path of the file to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the file.
+    pub fn get<P: AsRef<str>>(&self, bucket: P, file_path: P) -> Result<File> {
+        let path = self
+            .root
+            .path()
+            .join(bucket.as_ref())
+            .join(file_path.as_ref());
+        debug!(
+            "FakeS3Server: reading from bucket {}, file_path {}, fs path {}",
+            bucket.as_ref(),
+            file_path.as_ref(),
+            path.to_str().unwrap()
+        );
+        Ok(File::open(path)?)
+    }
+
+    /// Stores bytes into a file in the specified bucket.
+    ///
+    /// # Arguments
+    ///
+    /// * `bucket` - The name of the bucket.
+    /// * `file_path` - The path of the file to store.
+    /// * `contents` - The contents to store in the file.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating success or failure.
+    pub fn put_bytes<P: AsRef<str>>(&self, bucket: P, file_path: P, contents: &[u8]) -> Result<()> {
+        let path = self
+            .root
+            .path()
+            .join(bucket.as_ref())
+            .join(file_path.as_ref());
+        debug!(
+            "FakeS3Server: save bytes into bucket {}, file_path {}, fs path {}",
+            bucket.as_ref(),
+            file_path.as_ref(),
+            path.to_str().unwrap()
+        );
+        std::fs::File::create(path)
+            .context("Open file for write")?
+            .write_all(contents)
+            .context("Writing file contents")?;
+        Ok(())
+    }
+
+    /// Discards the fake S3 server, cancelling any ongoing operations.
+    pub fn discard(self) {
+        self.cancel.cancel();
+        self.handle.abort();
+    }
+}

--- a/s3-server/src/lib.rs
+++ b/s3-server/src/lib.rs
@@ -125,7 +125,7 @@ impl FakeS3Server {
             .await
             .context("FakeS3Server: tcp listener binding")?;
 
-        let result = tokio::select! {
+        tokio::select! {
             result = listener.accept() => {
                 let (socket, _) = match result {
                     Ok(ok) => ok,
@@ -143,7 +143,7 @@ impl FakeS3Server {
             }
             _ = cancel_token.cancelled() => bail!("FakeS3Server: cancelled")
         };
-        Ok(result)
+        Ok(())
     }
 
     /// Creates a new bucket in the fake S3 server.


### PR DESCRIPTION
This pull request introduces several changes and additions to the `rhio` project, as summarized below:

### Cargo.toml
1. Added `s3-server` as a new workspace member.
2. Added dependencies:
   - `s3-server` (path)
   - `s3s-fs` (version 0.10.0)
   - `s3s` (version 0.10.0)
   - `hyper-util` (version 0.1.10) with features `server`, `http1`, `http2`, and `tokio`

### rhio/Cargo.toml
1. Added `s3-server`, `s3s`, and `url` to the workspace.

### rhio/src/config.rs
1. Added `protocol` field to `NodeConfig`.
2. Introduced `ProtocolConfig` struct with `poll_interval_seconds` and `resync_interval_seconds`.
3. Added `Hash` trait for several structs including `NodeConfig`, `KnownNode`, `ProtocolConfig`, `PublishConfig`, `SubscribeConfig`, `RemoteS3Bucket`, `LocalNatsSubject`, and `RemoteNatsSubject`.

### rhio/src/context_builder.rs
1. Modified `SyncConfiguration` to include `protocol` configuration from `NodeConfig`.

### rhio/src/tests/blob_replication.rs
1. Added a new test file for end-to-end blob replication tests.
2. Implemented a test `test_e2e_blob_replication` to verify blob replication between source and target.

### rhio/src/tests/configuration.rs
1. Introduced `TwoClusterBlobSetup` struct for two-cluster blob storage system setup.
2. Added `create_two_node_blob_setup` function to create a blob storage setup.
3. Added helper functions `new_s3_server`, `generate_s3_config`, and `configure_blob_subscription`.

### rhio/src/tests/mod.rs
1. Added `blob_replication` module.

### s3-server/Cargo.toml
1. Added a new `Cargo.toml` for `s3-server`.

### s3-server/src/lib.rs
1. Added a new library file for `s3-server`.

These changes primarily add support for a new `s3-server` component and enhance the existing configuration and testing infrastructure to support blob replication functionality.