### PR TITLE
Arm64 build fix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,15 +28,15 @@ jobs:
         config:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-latest
+          - os: ubuntu-latest-arm64
             target: aarch64-apple-darwin
         isMain:
           - ${{ github.ref == 'refs/heads/main' }}
-        exclude:
-          - config:
-              os: macos-latest
-              target: aarch64-apple-darwin
-            isMain: false
+        # exclude:
+        #   - config:
+        #       os: macos-latest
+        #       target: aarch64-apple-darwin
+        #     isMain: false
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,10 +117,10 @@ jobs:
         isMain:
           - ${{ github.ref == 'refs/heads/main' }}
 
-        exclude:
-          # ARM build is very slow, we build only for main branch
-          - platform: "linux/arm64"
-            isMain: false
+        # exclude:
+        #   # ARM build is very slow, we build only for main branch
+        #   - platform: "linux/arm64"
+        #     isMain: false
 
     defaults:
       run:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,11 +32,11 @@ jobs:
             target: aarch64-apple-darwin
         isMain:
           - ${{ github.ref == 'refs/heads/main' }}
-        # exclude:
-        #   - config:
-        #       os: macos-latest
-        #       target: aarch64-apple-darwin
-        #     isMain: false
+        exclude:
+          - config:
+              os: macos-latest
+              target: aarch64-apple-darwin
+            isMain: false
 
     steps:
       - name: Checkout repository
@@ -45,6 +45,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1
         with:
+          # disabled caching in the setup-rust because aarch64-apple-darwin build takes around 1 hour to start
           cache: false
           channel: ${{ env.RUST_TOOLCHAIN }}
 
@@ -114,11 +115,10 @@ jobs:
         isMain:
           - ${{ github.ref == 'refs/heads/main' }}
 
-        # exclude:
-
-          # # ARM build is very slow, we build only for main branch
-          # - platform: "linux/arm64"
-          #   isMain: false
+        exclude:
+          # ARM build is very slow, we build only for main branch
+          - platform: "linux/arm64"
+            isMain: false
 
     name: Docker Build / ${{ matrix.platform }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,9 +111,6 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-        # os:
-        #   - ubuntu-latest
-        #   - ubuntu-22.04
         isMain:
           - ${{ github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,9 @@ jobs:
         with:
           channel: ${{ env.RUST_TOOLCHAIN }}
 
+      # build speedups
+      - uses: Swatinem/rust-cache@v2    
+
       - name: Run tests
         # Ensure debug output is also tested
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
         config:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest-arm64
+          - os: macos-latest
             target: aarch64-apple-darwin
         isMain:
           - ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,10 +115,6 @@ jobs:
           - ${{ github.ref == 'refs/heads/main' }}
 
         # exclude:
-          # - platform: linux/arm64
-          #   os: ubuntu-latest
-          # - platform: linux/amd64
-          #   os: ubuntu-22.04
 
           # # ARM build is very slow, we build only for main branch
           # - platform: "linux/arm64"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1
         with:
+          cache: false
           channel: ${{ env.RUST_TOOLCHAIN }}
 
       # build speedups

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,23 +105,31 @@ jobs:
           target_dir: ${{ env.HELM_CHART_TARGET_DIR }}
 
   build-docker:
-    name: Docker Build / ${{ matrix.platform }}
-    runs-on: ubuntu-latest
-    needs: [test]
-
     strategy:
       fail-fast: false
       matrix:
         platform:
           - linux/amd64
           - linux/arm64
+        # os:
+        #   - ubuntu-latest
+        #   - ubuntu-22.04
         isMain:
           - ${{ github.ref == 'refs/heads/main' }}
 
         # exclude:
-        #   # ARM build is very slow, we build only for main branch
-        #   - platform: "linux/arm64"
-        #     isMain: false
+          # - platform: linux/arm64
+          #   os: ubuntu-latest
+          # - platform: linux/amd64
+          #   os: ubuntu-22.04
+
+          # # ARM build is very slow, we build only for main branch
+          # - platform: "linux/arm64"
+          #   isMain: false
+
+    name: Docker Build / ${{ matrix.platform }}
+    runs-on: ubuntu-22.04
+    needs: [test]
 
     defaults:
       run:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -20,6 +20,9 @@ jobs:
         with:
           channel: ${{ env.RUST_TOOLCHAIN }}
 
+      # build speedups
+      - uses: Swatinem/rust-cache@v2    
+
       - name: Check project and dependencies
         run: cargo check
 
@@ -36,6 +39,9 @@ jobs:
           components: rustfmt
           channel: ${{ env.RUST_TOOLCHAIN }}
 
+      # build speedups
+      - uses: Swatinem/rust-cache@v2    
+
       - name: Check formatting
         run: cargo fmt -- --check
 
@@ -51,6 +57,9 @@ jobs:
         with:
           components: clippy
           channel: ${{ env.RUST_TOOLCHAIN }}
+
+      # build speedups
+      - uses: Swatinem/rust-cache@v2    
 
       - name: Check code with clippy
         run: cargo clippy -- -D warnings --no-deps

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1
         with:
+          cache: false
           channel: ${{ env.RUST_TOOLCHAIN }}
 
       # build speedups
@@ -36,6 +37,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1
         with:
+          cache: false
           components: rustfmt
           channel: ${{ env.RUST_TOOLCHAIN }}
 
@@ -55,6 +57,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1
         with:
+          cache: false
           components: clippy
           channel: ${{ env.RUST_TOOLCHAIN }}
 


### PR DESCRIPTION
**Summary:**
This pull request introduces several improvements and modifications to the GitHub Actions workflows for building and testing the Rust project. 

**Changes:**
1. **Workflow `.github/workflows/build.yaml`:**
   - Added a comment explaining the disabling of caching in the `setup-rust` action due to long build times for `aarch64-apple-darwin`.
   - Disabled caching in the `setup-rust` action.
   - Added `rust-cache` action to improve build speeds.
   - Updated the runner to `ubuntu-22.04`.

2. **Workflow `.github/workflows/rust.yaml`:**
   - Disabled caching in the `setup-rust` action across multiple job steps.
   - Added `rust-cache` action to improve build speeds in multiple job steps.

**Rationale:**
- **Disabling Cache in `setup-rust`:** The cache was disabled because the `aarch64-apple-darwin` build takes around 1 hour to start when caching is enabled.
- **Adding `rust-cache`:** Introducing `rust-cache` helps speed up the build process by caching dependencies and other build artifacts.
- **Docker Build Adjustments:** Updated the runner to `ubuntu-22.04` for better compatibility.

**Impact:**
These changes are aimed at improving the reliability and speed of the CI/CD workflows, particularly for Rust builds and Docker image creation.

